### PR TITLE
create `AnnotationPipeline`

### DIFF
--- a/src/pie_core/__init__.py
+++ b/src/pie_core/__init__.py
@@ -1,3 +1,4 @@
+from pie_core.annotation_pipeline import AnnotationPipeline, AutoAnnotationPipeline
 from pie_core.auto import Auto
 from pie_core.document import Annotation, AnnotationLayer, Document, annotation_field
 from pie_core.metric import DocumentMetric

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -18,8 +18,8 @@ class AnnotationPipeline(
     HyperparametersMixin,
     Registrable["AnnotationPipeline"],
 ):
-    MODEL_BASE_CLASS = AutoModel
-    TASKMODULE_BASE_CLASS = AutoTaskModule
+    auto_model_class = AutoModel
+    auto_taskmodule_class = AutoTaskModule
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
@@ -86,7 +86,7 @@ class AnnotationPipeline(
             model = model_or_model_kwargs
         else:
             # otherwise, create a new Model instance via AutoModel
-            model = cls.MODEL_BASE_CLASS.from_pretrained(
+            model = cls.auto_model_class.from_pretrained(
                 pretrained_model_name_or_path=pretrained_model_name_or_path,
                 force_download=force_download,
                 resume_download=resume_download,
@@ -104,7 +104,7 @@ class AnnotationPipeline(
             # otherwise:
             # 1. try to retrieve the taskmodule config
             taskmodule_config, remaining_taskmodule_kwargs = (
-                cls.TASKMODULE_BASE_CLASS.retrieve_config(
+                cls.auto_taskmodule_class.retrieve_config(
                     model_id=pretrained_model_name_or_path,
                     force_download=force_download,
                     resume_download=resume_download,
@@ -119,7 +119,7 @@ class AnnotationPipeline(
             # 2. If either the taskmodule config or the original taskmodule kwargs are not None,
             #    create a taskmodule from the config and / or kwargs
             if taskmodule_config is not None or taskmodule_or_taskmodule_kwargs is not None:
-                taskmodule = cls.TASKMODULE_BASE_CLASS.from_config(
+                taskmodule = cls.auto_taskmodule_class.from_config(
                     config=taskmodule_config or {}, **remaining_taskmodule_kwargs
                 )
             # 4. If the taskmodule is still None, do not create a taskmodule.

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -5,11 +5,12 @@ from typing import Any, Dict, Generic, Optional, Sequence, TypeVar, Union, overl
 
 from pytorch_lightning.core.mixins import HyperparametersMixin
 
-from pie_core import AutoModel, AutoTaskModule, Model, TaskModule
 from pie_core.auto import Auto
 from pie_core.document import Document
 from pie_core.hf_hub_mixin import AnnotationPipelineHFHubMixin
+from pie_core.model import AutoModel, Model
 from pie_core.registrable import Registrable
+from pie_core.taskmodule import AutoTaskModule, TaskModule
 
 logger = logging.getLogger(__name__)
 

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -88,7 +88,17 @@ class AnnotationPipeline(
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
-        config[self.config_type_key] = self.base_class().name_for_object_class(self)
+        if self.has_base_class():
+            config[self.config_type_key] = self.base_class().name_for_object_class(self)
+        else:
+            logger.warning(
+                f"{self.__class__.__name__} does not have a base class. It will not work"
+                " with AutoAnnotationPipeline.from_pretrained() or"
+                " AutoAnnotationPipeline.from_config(). Consider to annotate the class with"
+                " @AnnotationPipeline.register() or @AnnotationPipeline.register(name='...')"
+                " to register it as an AnnotationPipeline which will allow to load it via"
+                " AutoAnnotationPipeline."
+            )
         # add all hparams
         config.update(self.hparams)
         return config

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -26,8 +26,23 @@ class AnnotationPipeline(
             kwargs: Additional keyword arguments to pass to the parent class.
         """
         super().__init__(**kwargs)
-        self.model = model
-        self.taskmodule = taskmodule
+        self._model = model
+        self._taskmodule = taskmodule
+
+    @property
+    def model(self) -> Model:
+        """Get the model used by the pipeline."""
+        return self._model
+
+    @property
+    def taskmodule(self) -> TaskModule:
+        """Get the task module used by the pipeline."""
+        if self._taskmodule is not None:
+            return self._taskmodule
+        elif hasattr(self.model, "taskmodule"):
+            return self.model.taskmodule
+        else:
+            raise ValueError("No taskmodule found in the model. Please provide a taskmodule.")
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -29,6 +29,7 @@ class AnnotationPipeline(
 
     def __init__(self, model: TModel, taskmodule: Optional[TTaskModule] = None, **kwargs):
         super().__init__(**kwargs)
+        self.save_hyperparameters(ignore=["model", "taskmodule"])
         self._model = model
         self._taskmodule = taskmodule
 

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -93,11 +93,6 @@ class AnnotationPipeline(
         config.update(self.hparams)
         return config
 
-    def _save_pretrained(self, save_directory) -> None:
-        raise NotImplementedError(
-            "AnnotationPipeline does not yet support saving to file or the Huggingface Hub."
-        )
-
     @overload
     def __call__(
         self,

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -97,11 +97,6 @@ class AnnotationPipeline(
         **kwargs,
     ) -> Union[Document, Sequence[Document]]: ...
 
-
-class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeline]):
-
-    BASE_CLASS = AnnotationPipeline
-
     @classmethod
     def from_pretrained(
         cls,
@@ -183,3 +178,8 @@ class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeli
         )
 
         return pipeline
+
+
+class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeline]):
+
+    BASE_CLASS = AnnotationPipeline

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -112,15 +112,12 @@ class AnnotationPipeline(
             )
             # set is_from_pretrained to True
             remaining_taskmodule_kwargs["is_from_pretrained"] = True
-            # 2. If the taskmodule config is not None, create a taskmodule from it
-            if taskmodule_config is not None:
-                # the taskmodule_kwargs are already consumed, so we do not pass them again
+            # 2. If either the taskmodule config or the original taskmodule kwargs are not None,
+            #    create a taskmodule from the config and / or kwargs
+            if taskmodule_config is not None or taskmodule_or_taskmodule_kwargs is not None:
                 taskmodule = AutoTaskModule.from_config(
-                    config=taskmodule_config, **remaining_taskmodule_kwargs
+                    config=taskmodule_config or {}, **remaining_taskmodule_kwargs
                 )
-            # 3. If the taskmodule config is None, create a taskmodule from the kwargs
-            elif taskmodule_or_taskmodule_kwargs is not None:
-                taskmodule = AutoTaskModule.from_config(config={}, **remaining_taskmodule_kwargs)
             # 4. If the taskmodule is still None, do not create a taskmodule.
             #    It is assumed that the model contains the taskmodule.
             else:

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Sequence, Type, Union, overload
+from typing import Any, Dict, Optional, Sequence, Union, overload
 
 from pytorch_lightning.core.mixins import HyperparametersMixin
 

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Sequence, Union, overload
+from typing import Any, Dict, Generic, Optional, Sequence, TypeVar, Union, overload
 
 from pytorch_lightning.core.mixins import HyperparametersMixin
 
@@ -12,11 +12,17 @@ from pie_core.registrable import Registrable
 
 logger = logging.getLogger(__name__)
 
+TModel = TypeVar("TModel", bound=Model)
+TTaskModule = TypeVar("TTaskModule", bound=TaskModule)
+
 
 class AnnotationPipeline(
-    AnnotationPipelineHFHubMixin, HyperparametersMixin, Registrable["AnnotationPipeline"]
+    AnnotationPipelineHFHubMixin,
+    HyperparametersMixin,
+    Registrable["AnnotationPipeline"],
+    Generic[TModel, TTaskModule],
 ):
-    def __init__(self, model: Model, taskmodule: Optional[TaskModule] = None, **kwargs):
+    def __init__(self, model: TModel, taskmodule: Optional[TTaskModule] = None, **kwargs):
         """Initialize the AnnotationPipeline.
 
         The taskmodule is optional, it may be embedded in the model.
@@ -30,16 +36,16 @@ class AnnotationPipeline(
         self._taskmodule = taskmodule
 
     @property
-    def model(self) -> Model:
+    def model(self) -> TModel:
         """Get the model used by the pipeline."""
         return self._model
 
     @model.setter
-    def model(self, model: Model) -> None:
+    def model(self, model: TModel) -> None:
         self._model = model
 
     @property
-    def taskmodule(self) -> TaskModule:
+    def taskmodule(self) -> TTaskModule:
         """Get the task module used by the pipeline."""
         if self._taskmodule is not None:
             return self._taskmodule
@@ -49,7 +55,7 @@ class AnnotationPipeline(
             raise ValueError("No taskmodule found in the model. Please provide a taskmodule.")
 
     @taskmodule.setter
-    def taskmodule(self, taskmodule: Optional[TaskModule]) -> None:
+    def taskmodule(self, taskmodule: Optional[TTaskModule]) -> None:
         self._taskmodule = taskmodule
 
     def _config(self) -> Dict[str, Any]:

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -12,9 +12,6 @@ from pie_core.registrable import Registrable
 
 logger = logging.getLogger(__name__)
 
-TModel = TypeVar("TModel", bound=Model)
-TTaskModule = TypeVar("TTaskModule", bound=TaskModule)
-
 
 class AnnotationPipeline(
     AnnotationPipelineHFHubMixin,

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -34,6 +34,10 @@ class AnnotationPipeline(
         """Get the model used by the pipeline."""
         return self._model
 
+    @model.setter
+    def model(self, model: Model) -> None:
+        self._model = model
+
     @property
     def taskmodule(self) -> TaskModule:
         """Get the task module used by the pipeline."""
@@ -43,6 +47,10 @@ class AnnotationPipeline(
             return self.model.taskmodule
         else:
             raise ValueError("No taskmodule found in the model. Please provide a taskmodule.")
+
+    @taskmodule.setter
+    def taskmodule(self, taskmodule: Optional[TaskModule]) -> None:
+        self._taskmodule = taskmodule
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -1,0 +1,129 @@
+from abc import abstractmethod
+from typing import Any, Dict, Optional, Sequence, Type, Union, overload
+
+from pytorch_lightning.core.mixins import HyperparametersMixin
+
+from pie_core import AutoModel, AutoTaskModule, Model, TaskModule
+from pie_core.auto import Auto
+from pie_core.document import Document
+from pie_core.hf_hub_mixin import AnnotationPipelineHFHubMixin
+from pie_core.registrable import Registrable
+
+
+class AnnotationPipeline(
+    AnnotationPipelineHFHubMixin, HyperparametersMixin, Registrable["AnnotationPipeline"]
+):
+    def __init__(self, model: Model, taskmodule: Optional[TaskModule] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.model = model
+        self.taskmodule = taskmodule
+
+    def _config(self) -> Dict[str, Any]:
+        config = super()._config() or {}
+        config[self.config_type_key] = self.base_class().name_for_object_class(self)
+        # add all hparams
+        config.update(self.hparams)
+        return config
+
+    def _save_pretrained(self, save_directory) -> None:
+        raise NotImplementedError(
+            "AnnotationPipeline does not yet support saving to file or the Huggingface Hub."
+        )
+
+    @overload
+    def __call__(
+        self,
+        documents: Document,
+        inplace: bool = True,
+        *args,
+        **kwargs,
+    ) -> Document: ...
+
+    @overload
+    def __call__(
+        self,
+        documents: Sequence[Document],
+        inplace: bool = True,
+        *args,
+        **kwargs,
+    ) -> Sequence[Document]: ...
+
+    @abstractmethod
+    def __call__(
+        self,
+        documents: Union[Document, Sequence[Document]],
+        inplace: bool = True,
+        *args,
+        **kwargs,
+    ) -> Union[Document, Sequence[Document]]: ...
+
+
+class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeline]):
+
+    BASE_CLASS = AnnotationPipeline
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Dict] = None,
+        use_auth_token: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        local_files_only: bool = False,
+        device: int = -1,
+        binary_output: bool = False,
+        **kwargs,
+    ) -> "AnnotationPipeline":
+        taskmodule_kwargs = kwargs.pop("taskmodule_kwargs")
+        model_kwargs = kwargs.pop("model_kwargs")
+
+        model = AutoModel.from_pretrained(
+            pretrained_model_name_or_path=pretrained_model_name_or_path,
+            force_download=force_download,
+            resume_download=resume_download,
+            proxies=proxies,
+            use_auth_token=use_auth_token,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            **(model_kwargs or {}),
+        )
+
+        # TODO: Use AutoTaskModule.retrieve_config to check if a taskmodule config
+        # is available, and then:
+        #   - use AutoTaskModule.from_config to create the taskmodule (pass taskmodule_kwargs)
+        # If no config is available:
+        #   - raise an error if taskmodule_kwargs is not empty,
+        #   - raise an error if model.taskmodule is not available (after the model is created).
+        # Requires https://github.com/ArneBinder/pie-core/pull/28.
+        taskmodule = AutoTaskModule.from_pretrained(
+            pretrained_model_name_or_path=pretrained_model_name_or_path,
+            force_download=force_download,
+            resume_download=resume_download,
+            proxies=proxies,
+            use_auth_token=use_auth_token,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            **(taskmodule_kwargs or {}),
+        )
+
+        kwargs["taskmodule"] = taskmodule
+        kwargs["model"] = model
+
+        pipeline = super().from_pretrained(
+            pretrained_model_name_or_path=pretrained_model_name_or_path,
+            force_download=force_download,
+            resume_download=resume_download,
+            proxies=proxies,
+            use_auth_token=use_auth_token,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            taskmodule_kwargs=taskmodule_kwargs,
+            model_kwargs=model_kwargs,
+            device=device,
+            binary_output=binary_output,
+            **kwargs,
+        )
+
+        return pipeline

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -102,11 +102,11 @@ class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeli
         binary_output: bool = False,
         **kwargs,
     ) -> "AnnotationPipeline":
-        taskmodule_or_taskmodule_kwargs = kwargs.pop("taskmodule")
+        taskmodule_or_taskmodule_kwargs = kwargs.pop("taskmodule", None)
         if "taskmodule_kwargs" in kwargs:
             logger.warning("taskmodule_kwargs is deprecated. Use taskmodule instead.")
             taskmodule_or_taskmodule_kwargs = kwargs.pop("taskmodule_kwargs")
-        model_or_model_kwargs = kwargs.pop("model")
+        model_or_model_kwargs = kwargs.pop("model", None)
         if "model_kwargs" in kwargs:
             logger.warning("model_kwargs is deprecated. Use model instead.")
             model_or_model_kwargs = kwargs.pop("model_kwargs")

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, Generic, Optional, Sequence, TypeVar, Union, overload
+from typing import Any, Dict, Optional, Sequence, TypeVar, Union, overload
 
 from pytorch_lightning.core.mixins import HyperparametersMixin
 
@@ -20,43 +20,7 @@ class AnnotationPipeline(
     AnnotationPipelineHFHubMixin,
     HyperparametersMixin,
     Registrable["AnnotationPipeline"],
-    Generic[TModel, TTaskModule],
 ):
-    def __init__(self, model: TModel, taskmodule: Optional[TTaskModule] = None, **kwargs):
-        """Initialize the AnnotationPipeline.
-
-        The taskmodule is optional, it may be embedded in the model.
-        Args:
-            model: The model to use for the pipeline.
-            taskmodule: The task module to use for the pipeline.
-            kwargs: Additional keyword arguments to pass to the parent class.
-        """
-        super().__init__(**kwargs)
-        self._model = model
-        self._taskmodule = taskmodule
-
-    @property
-    def model(self) -> TModel:
-        """Get the model used by the pipeline."""
-        return self._model
-
-    @model.setter
-    def model(self, model: TModel) -> None:
-        self._model = model
-
-    @property
-    def taskmodule(self) -> TTaskModule:
-        """Get the task module used by the pipeline."""
-        if self._taskmodule is not None:
-            return self._taskmodule
-        elif hasattr(self.model, "taskmodule"):
-            return self.model.taskmodule
-        else:
-            raise ValueError("No taskmodule found in the model. Please provide a taskmodule.")
-
-    @taskmodule.setter
-    def taskmodule(self, taskmodule: Optional[TTaskModule]) -> None:
-        self._taskmodule = taskmodule
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
@@ -163,8 +127,9 @@ class AnnotationPipeline(
             else:
                 taskmodule = None
 
-        kwargs["taskmodule"] = taskmodule
         kwargs["model"] = model
+        if taskmodule is not None:
+            kwargs["taskmodule"] = taskmodule
 
         pipeline = super().from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
@@ -180,6 +145,6 @@ class AnnotationPipeline(
         return pipeline
 
 
-class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeline]):
+class AutoAnnotationPipeline(AnnotationPipeline, Auto[AnnotationPipeline]):
 
     BASE_CLASS = AnnotationPipeline

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -101,7 +101,7 @@ class AnnotationPipeline(
         else:
             # otherwise:
             # 1. try to retrieve the taskmodule config
-            taskmodule_config = AutoTaskModule.retrieve_config(
+            taskmodule_config, remaining_taskmodule_kwargs = AutoTaskModule.retrieve_config(
                 model_id=pretrained_model_name_or_path,
                 force_download=force_download,
                 resume_download=resume_download,
@@ -110,17 +110,17 @@ class AnnotationPipeline(
                 local_files_only=local_files_only,
                 **(taskmodule_or_taskmodule_kwargs or {}),
             )
+            # set is_from_pretrained to True
+            remaining_taskmodule_kwargs["is_from_pretrained"] = True
             # 2. If the taskmodule config is not None, create a taskmodule from it
             if taskmodule_config is not None:
                 # the taskmodule_kwargs are already consumed, so we do not pass them again
                 taskmodule = AutoTaskModule.from_config(
-                    config=taskmodule_config, is_from_pretrained=True
+                    config=taskmodule_config, **remaining_taskmodule_kwargs
                 )
             # 3. If the taskmodule config is None, create a taskmodule from the kwargs
             elif taskmodule_or_taskmodule_kwargs is not None:
-                taskmodule_kwargs = taskmodule_or_taskmodule_kwargs.copy()
-                taskmodule_kwargs["is_from_pretrained"] = True
-                taskmodule = AutoTaskModule.from_config(config={}, **taskmodule_kwargs)
+                taskmodule = AutoTaskModule.from_config(config={}, **remaining_taskmodule_kwargs)
             # 4. If the taskmodule is still None, do not create a taskmodule.
             #    It is assumed that the model contains the taskmodule.
             else:

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -1,5 +1,5 @@
 import logging
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Generic, Optional, Sequence, TypeVar, Union, overload
 
@@ -23,6 +23,7 @@ class AnnotationPipeline(
     HyperparametersMixin,
     Registrable["AnnotationPipeline"],
     Generic[TModel, TTaskModule],
+    ABC,
 ):
     auto_model_class = AutoModel
     auto_taskmodule_class = AutoTaskModule

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -98,8 +98,6 @@ class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeli
         use_auth_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
         local_files_only: bool = False,
-        device: int = -1,
-        binary_output: bool = False,
         **kwargs,
     ) -> "AnnotationPipeline":
         taskmodule_or_taskmodule_kwargs = kwargs.pop("taskmodule", None)
@@ -167,8 +165,6 @@ class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeli
             use_auth_token=use_auth_token,
             cache_dir=cache_dir,
             local_files_only=local_files_only,
-            device=device,
-            binary_output=binary_output,
             **kwargs,
         )
 

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -113,12 +113,14 @@ class AnnotationPipeline(
             # 2. If the taskmodule config is not None, create a taskmodule from it
             if taskmodule_config is not None:
                 # the taskmodule_kwargs are already consumed, so we do not pass them again
-                taskmodule = AutoTaskModule.from_config(config=taskmodule_config)
+                taskmodule = AutoTaskModule.from_config(
+                    config=taskmodule_config, is_from_pretrained=True
+                )
             # 3. If the taskmodule config is None, create a taskmodule from the kwargs
             elif taskmodule_or_taskmodule_kwargs is not None:
-                taskmodule = AutoTaskModule.from_config(
-                    config={}, **taskmodule_or_taskmodule_kwargs
-                )
+                taskmodule_kwargs = taskmodule_or_taskmodule_kwargs.copy()
+                taskmodule_kwargs["is_from_pretrained"] = True
+                taskmodule = AutoTaskModule.from_config(config={}, **taskmodule_kwargs)
             # 4. If the taskmodule is still None, do not create a taskmodule.
             #    It is assumed that the model contains the taskmodule.
             else:

--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -507,3 +507,33 @@ class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
         taskmodule = cls.from_config(config=config or {}, **kwargs)
 
         return taskmodule
+
+
+TPipeline = TypeVar("TPipeline", bound="AnnotationPipelineHFHubMixin")
+
+
+class AnnotationPipelineHFHubMixin(PieBaseHFHubMixin):
+    config_name = "pipeline_config.json"
+    config_type_key = "pipeline_type"
+
+    @classmethod
+    def _from_pretrained(
+        cls: Type[TPipeline],
+        *,
+        model_id: str,
+        revision: Optional[str],
+        cache_dir: Optional[Union[str, Path]],
+        force_download: bool,
+        proxies: Optional[Dict],
+        resume_download: bool,
+        local_files_only: bool,
+        token: Union[str, bool, None],
+        map_location: str = "cpu",
+        strict: bool = False,
+        config: Optional[dict] = None,
+        **kwargs,
+    ) -> TPipeline:
+
+        pipeline = cls.from_config(config=config or {}, **kwargs)
+
+        return pipeline

--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -517,6 +517,9 @@ class AnnotationPipelineHFHubMixin(PieBaseHFHubMixin):
     config_name = "pipeline_config.json"
     config_type_key = "pipeline_type"
 
+    def _save_pretrained(self, save_directory) -> None:
+        return None
+
     @classmethod
     def _from_pretrained(
         cls: Type[TPipeline],

--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import requests
 from huggingface_hub.constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
@@ -115,7 +115,8 @@ class PieBaseHFHubMixin:
         local_files_only: bool = False,
         revision: Optional[str] = None,
         fail_silently: bool = False,
-    ) -> Optional[Dict[str, Any]]:
+        **kwargs,
+    ) -> Tuple[Optional[Dict[str, Any]], Dict[str, Any]]:
         """Retrieve the configuration file from the Huggingface Hub or local directory.
 
         Returns None if the config file is not found.
@@ -147,8 +148,8 @@ class PieBaseHFHubMixin:
         if config_file is not None:
             with open(config_file, encoding="utf-8") as f:
                 config = json.load(f)
-            return config
-        return None
+            return config, kwargs
+        return None, kwargs
 
     @classmethod
     @validate_hf_hub_args
@@ -195,7 +196,7 @@ class PieBaseHFHubMixin:
         """
         model_id = pretrained_model_name_or_path
 
-        config = cls.retrieve_config(
+        config, _ = cls.retrieve_config(
             model_id=model_id,
             revision=revision,
             cache_dir=cache_dir,


### PR DESCRIPTION
implements #45, in details:
 - `AnnotationPipelineHFHubMixin`,
 - `AnnotationPipeline` 
     - including `from_pretrained` which relays on `.auto_model_class` and `.auto_taskmodule_class` to load the model and taskmodule, respectively
 - `AutoAnnotationPipeline`

Notes: 
- This fixes `PieBaseHFHubMixin.retrieve_config` to return the unused `kwargs` in addition to the retrieved config.
- To use `PyTorchIEPipeline(AnnotationPipeline)` as backwards compatible replacement for `Pipeline` (and `AutoPipeline`) in `pytorch-ie`, just set  `PyTorchIEPipeline.auto_model_class = AutoPyTorchIEModel` and remove the implementation of `from_pretrained`.

TODO:
 - [ ] add documentation
 - [ ] add tests