### PR TITLE
lenient configs for `TaskModule` and `Model`

### DIFF
--- a/src/pie_core/model.py
+++ b/src/pie_core/model.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict
 
 from pytorch_lightning.core.mixins import HyperparametersMixin
@@ -6,12 +7,23 @@ from pie_core.auto import Auto
 from pie_core.hf_hub_mixin import PieModelHFHubMixin
 from pie_core.registrable import Registrable
 
+logger = logging.getLogger(__name__)
+
 
 class Model(PieModelHFHubMixin, HyperparametersMixin, Registrable["Model"]):
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
-        config[self.config_type_key] = self.base_class().name_for_object_class(self)
+        if self.has_base_class():
+            config[self.config_type_key] = self.base_class().name_for_object_class(self)
+        else:
+            logger.warning(
+                f"{self.__class__.__name__} does not have a base class. It will not work"
+                " with AutoModel.from_pretrained() or"
+                " AutoModel.from_config(). Consider to annotate the class with"
+                " @Model.register() or @Model.register(name='...') to register it at as a Model"
+                " which will allow to load it via AutoModel."
+            )
         # add all hparams
         config.update(self.hparams)
         return config

--- a/src/pie_core/registrable.py
+++ b/src/pie_core/registrable.py
@@ -20,9 +20,9 @@ class Registrable(Generic[T2]):
         """Returns the base class of this registrable class."""
         if cls.BASE_CLASS is None:
             raise RegistrationError(
-                f"{cls.__class__.__name__} has no base class. "
-                f"Please call {cls.__class__.__name__}.register() to register it or "
-                "manually set BASE_CLASS to a subclass of Registrable."
+                f"{cls.__name__} has no defined base class. "
+                f"Please annotate {cls.__name__} with @<SOME-PARENT-OF-{cls.__name__}>.register() "
+                f"to register it at <SOME-PARENT-OF-{cls.__name__}>."
             )
         return cls.BASE_CLASS
 

--- a/src/pie_core/registrable.py
+++ b/src/pie_core/registrable.py
@@ -27,6 +27,11 @@ class Registrable(Generic[T2]):
         return cls.BASE_CLASS
 
     @classmethod
+    def has_base_class(cls) -> bool:
+        """Returns True if this registrable class has a base class."""
+        return cls.BASE_CLASS is not None
+
+    @classmethod
     def register(
         cls: Type[T],
         name: Optional[str] = None,

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -66,7 +66,16 @@ class TaskModule(
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
-        config[self.config_type_key] = self.base_class().name_for_object_class(self)
+        if self.has_base_class():
+            config[self.config_type_key] = self.base_class().name_for_object_class(self)
+        else:
+            logger.warning(
+                f"{self.__class__.__name__} does not have a base class. It will not work "
+                "with AutoTaskModule.from_pretrained() or "
+                "AutoTaskModule.from_config(). Consider to annotate the class with "
+                "@TaskModule.register() or @TaskModule.register(name='...') "
+                "to register it as a TaskModule which will allow to load it via AutoTaskModule."
+            )
         # add all hparams
         config.update(self.hparams)
         # add all prepared attributes


### PR DESCRIPTION
With this PR, it is still possible to get a `config` from `TaskModule` and `Model` instances if they are not registered.

In detail, this PR:
 - adds `Registrable.has_base_class()`
 - fixes the error message in `Registrable.base_class()` if no `BASE_CLASS` is defined
 - changed `_config()` methods in `TaskModule` and `Model` to not add the type to configs if no base class is defined (i.e., it is not registered) but shows a warning instead that `Auto*.from_pretrained()` will not work