### PR TITLE
fix `release` CI worflow again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,12 @@ on:
         branches:
             - main
 
-permissions:
-  contents: read
-
 jobs:
     release:
         name: Release
         permissions:
           # write permission is required for "Detect and tag new version"
+          # as well as for "Publish the release notes"
           contents: write
         runs-on: ubuntu-latest
         steps:
@@ -77,28 +75,13 @@ jobs:
                 password: ${{ secrets.TEST_PYPI_TOKEN }}
                 repository_url: https://test.pypi.org/legacy/
 
-    #----------------------------------------------
-    #  -----  create github release notes -----
-    #----------------------------------------------
-    update_release_draft:
-        name: Update Release Draft
-        needs: release
-        permissions:
-            # write permission is required to create a github release
-            contents: write
-            # write permission is required for autolabeler
-            # otherwise, read permission is required at least
-            pull-requests: write
-        runs-on: ubuntu-latest
-        steps:
-            # Drafts your next Release notes as Pull Requests are merged into "master"
-            - uses: release-drafter/release-drafter@v6
-              # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-              # with:
-              #   config-name: my-config.yml
-              #   disable-autolabeler: true
-              with:
-                  publish: ${{ steps.check-version.outputs.tag != '' }}
-                  tag: ${{ steps.check-version.outputs.tag }}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          #----------------------------------------------
+          #  -----  create github release notes -----
+          #----------------------------------------------
+          - name: Publish the release notes
+            uses: release-drafter/release-drafter@v6
+            with:
+                publish: ${{ steps.check-version.outputs.tag != '' }}
+                tag: ${{ steps.check-version.outputs.tag }}
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     release:
         name: Release


### PR DESCRIPTION
This aligns the `release.yml` workflow more with the original version (borrowed from [pie-modules](https://github.com/ArneBinder/pie-modules/blob/main/.github/workflows/release.yml)), but with added permissions according to https://github.com/release-drafter/release-drafter?tab=readme-ov-file#usage.

It looks like the release was not properly created on GitHub until now, I needed to manually make the Draft a real release (and assigning the correct tag). But the release was properly published on [pypy.org](https://pypi.org/project/pie-core/).