### PR TITLE
streamline `hf_hub_mixin`

### DIFF
--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -126,14 +126,12 @@ TTaskModule = TypeVar("TTaskModule", bound="TaskModule")
 
 
 class AnnotationPipeline(
-    PieBaseHFHubMixin,
+    AnnotationPipelineHFHubMixin,
     HyperparametersMixin,
     Registrable["AnnotationPipeline"],
     Generic[TModel, TTaskModule],
     ABC,
 ):
-    config_name = "pipeline_config.json"
-    config_type_key = "pipeline_type"
 
     def __init__(self, model: TModel, taskmodule: Optional[TTaskModule] = None, **kwargs):
         super().__init__(**kwargs)

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -1,32 +1,141 @@
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Generic, Optional, Sequence, TypeVar, Union, overload
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from pytorch_lightning.core.mixins import HyperparametersMixin
 
 from pie_core.auto import Auto
 from pie_core.document import Document
-from pie_core.hf_hub_mixin import AnnotationPipelineHFHubMixin
+from pie_core.hf_hub_mixin import PieBaseHFHubMixin
 from pie_core.model import AutoModel, Model
 from pie_core.registrable import Registrable
 from pie_core.taskmodule import AutoTaskModule, TaskModule
 
 logger = logging.getLogger(__name__)
 
+
+TAnnotationPipelineHFHubMixin = TypeVar(
+    "TAnnotationPipelineHFHubMixin", bound="AnnotationPipelineHFHubMixin"
+)
+
+
+class AnnotationPipelineHFHubMixin(PieBaseHFHubMixin):
+    config_name = "pipeline_config.json"
+    config_type_key = "pipeline_type"
+    auto_model_class = AutoModel
+    auto_taskmodule_class = AutoTaskModule
+
+    @classmethod
+    def from_pretrained(
+        cls: Type[TAnnotationPipelineHFHubMixin],
+        pretrained_model_name_or_path: str,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Dict] = None,
+        use_auth_token: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> TAnnotationPipelineHFHubMixin:
+        taskmodule_or_taskmodule_kwargs = kwargs.pop("taskmodule", None)
+        if "taskmodule_kwargs" in kwargs:
+            logger.warning("taskmodule_kwargs is deprecated. Use taskmodule instead.")
+            taskmodule_or_taskmodule_kwargs = kwargs.pop("taskmodule_kwargs")
+        model_or_model_kwargs = kwargs.pop("model", None)
+        if "model_kwargs" in kwargs:
+            logger.warning("model_kwargs is deprecated. Use model instead.")
+            model_or_model_kwargs = kwargs.pop("model_kwargs")
+
+        if isinstance(model_or_model_kwargs, Model):
+            # if model is already a Model instance, use it directly
+            model = model_or_model_kwargs
+        else:
+            # otherwise, create a new Model instance via AutoModel
+            model = cls.auto_model_class.from_pretrained(
+                pretrained_model_name_or_path=pretrained_model_name_or_path,
+                force_download=force_download,
+                resume_download=resume_download,
+                proxies=proxies,
+                use_auth_token=use_auth_token,
+                cache_dir=cache_dir,
+                local_files_only=local_files_only,
+                **(model_or_model_kwargs or {}),
+            )
+
+        if isinstance(taskmodule_or_taskmodule_kwargs, TaskModule):
+            # if taskmodule is already a TaskModule instance, use it directly
+            taskmodule = taskmodule_or_taskmodule_kwargs
+        else:
+            # otherwise:
+            # 1. try to retrieve the taskmodule config file
+            taskmodule_config_file, _ = cls.auto_taskmodule_class.retrieve_config_file(
+                model_id=pretrained_model_name_or_path,
+                force_download=force_download,
+                resume_download=resume_download,
+                proxies=proxies,
+                cache_dir=cache_dir,
+                local_files_only=local_files_only,
+                **(taskmodule_or_taskmodule_kwargs or {}),
+            )
+            # 2. If the taskmodule config file is found, load the taskmodule via from_pretrained()
+            if taskmodule_config_file is not None:
+                taskmodule = cls.auto_taskmodule_class.from_pretrained(
+                    pretrained_model_name_or_path=pretrained_model_name_or_path,
+                    force_download=force_download,
+                    resume_download=resume_download,
+                    proxies=proxies,
+                    use_auth_token=use_auth_token,
+                    cache_dir=cache_dir,
+                    local_files_only=local_files_only,
+                    **(taskmodule_or_taskmodule_kwargs or {}),
+                )
+            # 3. Otherwise, do not load a taskmodule.
+            #    It is assumed that the model contains the taskmodule.
+            else:
+                taskmodule = None
+
+        kwargs["model"] = model
+        if taskmodule is not None:
+            kwargs["taskmodule"] = taskmodule
+
+        pipeline = super().from_pretrained(
+            pretrained_model_name_or_path=pretrained_model_name_or_path,
+            force_download=force_download,
+            resume_download=resume_download,
+            proxies=proxies,
+            use_auth_token=use_auth_token,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            **kwargs,
+        )
+
+        return pipeline
+
+
 TModel = TypeVar("TModel", bound="Model")
 TTaskModule = TypeVar("TTaskModule", bound="TaskModule")
 
 
 class AnnotationPipeline(
-    AnnotationPipelineHFHubMixin,
+    PieBaseHFHubMixin,
     HyperparametersMixin,
     Registrable["AnnotationPipeline"],
     Generic[TModel, TTaskModule],
     ABC,
 ):
-    auto_model_class = AutoModel
-    auto_taskmodule_class = AutoTaskModule
+    config_name = "pipeline_config.json"
+    config_type_key = "pipeline_type"
 
     def __init__(self, model: TModel, taskmodule: Optional[TTaskModule] = None, **kwargs):
         super().__init__(**kwargs)
@@ -131,93 +240,7 @@ class AnnotationPipeline(
         **kwargs,
     ) -> Union[Document, Sequence[Document]]: ...
 
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path: str,
-        force_download: bool = False,
-        resume_download: bool = False,
-        proxies: Optional[Dict] = None,
-        use_auth_token: Optional[str] = None,
-        cache_dir: Optional[str] = None,
-        local_files_only: bool = False,
-        **kwargs,
-    ) -> "AnnotationPipeline":
-        taskmodule_or_taskmodule_kwargs = kwargs.pop("taskmodule", None)
-        if "taskmodule_kwargs" in kwargs:
-            logger.warning("taskmodule_kwargs is deprecated. Use taskmodule instead.")
-            taskmodule_or_taskmodule_kwargs = kwargs.pop("taskmodule_kwargs")
-        model_or_model_kwargs = kwargs.pop("model", None)
-        if "model_kwargs" in kwargs:
-            logger.warning("model_kwargs is deprecated. Use model instead.")
-            model_or_model_kwargs = kwargs.pop("model_kwargs")
 
-        if isinstance(model_or_model_kwargs, Model):
-            # if model is already a Model instance, use it directly
-            model = model_or_model_kwargs
-        else:
-            # otherwise, create a new Model instance via AutoModel
-            model = cls.auto_model_class.from_pretrained(
-                pretrained_model_name_or_path=pretrained_model_name_or_path,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
-                use_auth_token=use_auth_token,
-                cache_dir=cache_dir,
-                local_files_only=local_files_only,
-                **(model_or_model_kwargs or {}),
-            )
-
-        if isinstance(taskmodule_or_taskmodule_kwargs, TaskModule):
-            # if taskmodule is already a TaskModule instance, use it directly
-            taskmodule = taskmodule_or_taskmodule_kwargs
-        else:
-            # otherwise:
-            # 1. try to retrieve the taskmodule config file
-            taskmodule_config_file, _ = cls.auto_taskmodule_class.retrieve_config_file(
-                model_id=pretrained_model_name_or_path,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
-                cache_dir=cache_dir,
-                local_files_only=local_files_only,
-                **(taskmodule_or_taskmodule_kwargs or {}),
-            )
-            # 2. If the taskmodule config file is found, load the taskmodule via from_pretrained()
-            if taskmodule_config_file is not None:
-                taskmodule = cls.auto_taskmodule_class.from_pretrained(
-                    pretrained_model_name_or_path=pretrained_model_name_or_path,
-                    force_download=force_download,
-                    resume_download=resume_download,
-                    proxies=proxies,
-                    use_auth_token=use_auth_token,
-                    cache_dir=cache_dir,
-                    local_files_only=local_files_only,
-                    **(taskmodule_or_taskmodule_kwargs or {}),
-                )
-            # 3. Otherwise, do not load a taskmodule.
-            #    It is assumed that the model contains the taskmodule.
-            else:
-                taskmodule = None
-
-        kwargs["model"] = model
-        if taskmodule is not None:
-            kwargs["taskmodule"] = taskmodule
-
-        pipeline = super().from_pretrained(
-            pretrained_model_name_or_path=pretrained_model_name_or_path,
-            force_download=force_download,
-            resume_download=resume_download,
-            proxies=proxies,
-            use_auth_token=use_auth_token,
-            cache_dir=cache_dir,
-            local_files_only=local_files_only,
-            **kwargs,
-        )
-
-        return pipeline
-
-
-class AutoAnnotationPipeline(AnnotationPipeline, Auto[AnnotationPipeline]):
+class AutoAnnotationPipeline(AnnotationPipelineHFHubMixin, Auto[AnnotationPipeline]):
 
     BASE_CLASS = AnnotationPipeline

--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -51,8 +51,6 @@ class AnnotationPipelineHFHubMixin(PieBaseHFHubMixin):
         resume_download: bool,
         local_files_only: bool,
         token: Union[str, bool, None],
-        map_location: str = "cpu",
-        strict: bool = False,
         config: Optional[dict] = None,
         **kwargs,
     ) -> TAnnotationPipelineHFHubMixin:

--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -96,7 +96,7 @@ class PieBaseHFHubMixin:
             save_directory (`str` or `Path`):
                 Path to directory in which the model weights and configuration will be saved.
         """
-        return None
+        raise NotImplementedError
 
     @classmethod
     def retrieve_config_file(
@@ -232,8 +232,7 @@ class PieBaseHFHubMixin:
         resume_download: bool,
         local_files_only: bool,
         token: Optional[Union[str, bool]],
-        config: Optional[dict] = None,
-        **kwargs,
+        **model_kwargs,
     ) -> T:
         """Overwrite this method in subclass to define how to load your model from pretrained.
 
@@ -268,9 +267,7 @@ class PieBaseHFHubMixin:
             model_kwargs:
                 Additional keyword arguments passed along to the [`~ModelHubMixin._from_pretrained`] method.
         """
-        module = cls.from_config(config=config or {}, **kwargs)
-
-        return module
+        raise NotImplementedError
 
     @validate_hf_hub_args
     def push_to_hub(

--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import requests
-from huggingface_hub.constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import SoftTemporaryDirectory, validate_hf_hub_args
@@ -14,10 +13,6 @@ from pie_core.utils.dictionary import TNestedBoolDict, dict_update_nested
 
 logger = logging.getLogger(__name__)
 
-MODEL_CONFIG_NAME = CONFIG_NAME
-TASKMODULE_CONFIG_NAME = "taskmodule_config.json"
-MODEL_CONFIG_TYPE_KEY = "model_type"
-TASKMODULE_CONFIG_TYPE_KEY = "taskmodule_type"
 
 # Generic variable that is either PieBaseHFHubMixin or a subclass thereof
 T = TypeVar("T", bound="PieBaseHFHubMixin")
@@ -31,8 +26,8 @@ class PieBaseHFHubMixin:
     of mixin integration with the Hub. Check out our [integration guide](../guides/integrations) for more instructions.
     """
 
-    config_name = MODEL_CONFIG_NAME
-    config_type_key = MODEL_CONFIG_TYPE_KEY
+    config_name = "not_implemented.json"
+    config_type_key = "not_implemented"
 
     def __init__(self, *args, is_from_pretrained: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
@@ -101,7 +96,7 @@ class PieBaseHFHubMixin:
             save_directory (`str` or `Path`):
                 Path to directory in which the model weights and configuration will be saved.
         """
-        raise NotImplementedError
+        return None
 
     @classmethod
     def retrieve_config_file(
@@ -237,7 +232,8 @@ class PieBaseHFHubMixin:
         resume_download: bool,
         local_files_only: bool,
         token: Optional[Union[str, bool]],
-        **model_kwargs,
+        config: Optional[dict] = None,
+        **kwargs,
     ) -> T:
         """Overwrite this method in subclass to define how to load your model from pretrained.
 
@@ -272,7 +268,9 @@ class PieBaseHFHubMixin:
             model_kwargs:
                 Additional keyword arguments passed along to the [`~ModelHubMixin._from_pretrained`] method.
         """
-        raise NotImplementedError
+        module = cls.from_config(config=config or {}, **kwargs)
+
+        return module
 
     @validate_hf_hub_args
     def push_to_hub(
@@ -375,205 +373,3 @@ class PieBaseHFHubMixin:
         config = config.copy()
         dict_update_nested(config, kwargs, override=config_override)
         return cls(**config)
-
-
-TModel = TypeVar("TModel", bound="PieModelHFHubMixin")
-
-
-class PieModelHFHubMixin(PieBaseHFHubMixin):
-    config_name = MODEL_CONFIG_NAME
-    config_type_key = MODEL_CONFIG_TYPE_KEY
-    weights_file_name = PYTORCH_WEIGHTS_NAME
-    """Implementation of [`PieBaseHFHubMixin`] to provide model Hub upload/download capabilities to
-    models.
-
-    Example for a Pytorch model:
-
-    ```python
-    >>> import torch
-    >>> import torch.nn as nn
-    >>> from pie_core import PieModelHFHubMixin
-
-
-    >>> class MyPytorchModel(nn.Module, PieModelHFHubMixin):
-    ...     def __init__(self):
-    ...         super().__init__()
-    ...         self.param = nn.Parameter(torch.rand(3, 4))
-    ...         self.linear = nn.Linear(4, 5)
-
-    ...     def forward(self, x):
-    ...         return self.linear(x + self.param)
-    ...
-    ...     def save_model_file(self, model_file: str) -> None:
-    ...         torch.save(self.state_dict(), model_file)
-    ...
-    ...     def load_model_file(
-    ...         self, model_file: str, map_location: str = "cpu", strict: bool = False
-    ...     ) -> None:
-    ...         state_dict = torch.load(model_file, map_location=torch.device(map_location))
-    ...         self.load_state_dict(state_dict, strict=strict)
-
-    >>> model = MyModel()
-
-    # Save model weights to local directory
-    >>> model.save_pretrained("my-awesome-model")
-
-    # Push model weights to the Hub
-    >>> model.push_to_hub("my-awesome-model")
-
-    # Download and initialize weights from the Hub
-    >>> model = MyModel.from_pretrained("username/my-awesome-model")
-    ```
-    """
-
-    def save_model_file(self, model_file: str) -> None:
-        """Save weights from a Pytorch model to a local directory."""
-        raise NotImplementedError
-
-    def load_model_file(
-        self, model_file: str, map_location: str = "cpu", strict: bool = False
-    ) -> None:
-        """Load weights from a Pytorch model file."""
-        raise NotImplementedError
-
-    def _save_pretrained(self, save_directory: Path) -> None:
-        """Save weights from a Pytorch model to a local directory."""
-        self.save_model_file(str(save_directory / self.weights_file_name))
-
-    @classmethod
-    def retrieve_model_file(
-        cls,
-        model_id: str,
-        revision: Optional[str] = None,
-        cache_dir: Optional[Union[str, Path]] = None,
-        force_download: bool = False,
-        proxies: Optional[Dict] = None,
-        resume_download: bool = False,
-        local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
-        **remaining_kwargs,
-    ) -> Tuple[str, Dict[str, Any]]:
-        """Retrieve the model file from the Huggingface Hub or local directory."""
-        if os.path.isdir(model_id):
-            logger.info("Loading weights from local directory")
-            model_file = os.path.join(model_id, cls.weights_file_name)
-        else:
-            model_file = hf_hub_download(
-                repo_id=model_id,
-                filename=cls.weights_file_name,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                proxies=proxies,
-                resume_download=resume_download,
-                token=token,
-                local_files_only=local_files_only,
-            )
-
-        return model_file, remaining_kwargs
-
-    @classmethod
-    def _from_pretrained(
-        cls: Type[TModel],
-        *,
-        model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Union[str, bool, None],
-        map_location: str = "cpu",
-        strict: bool = False,
-        config: Optional[dict] = None,
-        **kwargs,
-    ) -> TModel:
-
-        model_file, remaining_kwargs = cls.retrieve_model_file(
-            model_id=model_id,
-            revision=revision,
-            cache_dir=cache_dir,
-            force_download=force_download,
-            proxies=proxies,
-            resume_download=resume_download,
-            local_files_only=local_files_only,
-            token=token,
-            **kwargs,
-        )
-        model = cls.from_config(config=config or {}, **remaining_kwargs)
-
-        # TODO: map_location and strict are quite specific to PyTorch.
-        #  How to handle this in a more generic way?
-        model.load_model_file(model_file, map_location=map_location, strict=strict)
-
-        return model
-
-
-TTaskModule = TypeVar("TTaskModule", bound="PieTaskModuleHFHubMixin")
-
-
-class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
-    config_name = TASKMODULE_CONFIG_NAME
-    config_type_key = TASKMODULE_CONFIG_TYPE_KEY
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def _save_pretrained(self, save_directory) -> None:
-        return None
-
-    @classmethod
-    def _from_pretrained(
-        cls: Type[TTaskModule],
-        *,
-        model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Union[str, bool, None],
-        map_location: str = "cpu",
-        strict: bool = False,
-        config: Optional[dict] = None,
-        **kwargs,
-    ) -> TTaskModule:
-
-        taskmodule = cls.from_config(config=config or {}, **kwargs)
-
-        return taskmodule
-
-
-TPipeline = TypeVar("TPipeline", bound="AnnotationPipelineHFHubMixin")
-
-
-class AnnotationPipelineHFHubMixin(PieBaseHFHubMixin):
-    config_name = "pipeline_config.json"
-    config_type_key = "pipeline_type"
-
-    def _save_pretrained(self, save_directory) -> None:
-        return None
-
-    @classmethod
-    def _from_pretrained(
-        cls: Type[TPipeline],
-        *,
-        model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Union[str, bool, None],
-        map_location: str = "cpu",
-        strict: bool = False,
-        config: Optional[dict] = None,
-        **kwargs,
-    ) -> TPipeline:
-
-        pipeline = cls.from_config(config=config or {}, **kwargs)
-
-        return pipeline

--- a/src/pie_core/model.py
+++ b/src/pie_core/model.py
@@ -13,14 +13,14 @@ from pie_core.registrable import Registrable
 
 logger = logging.getLogger(__name__)
 
-TModel = TypeVar("TModel", bound="PieModelHFHubMixin")
+TModelHFHubMixin = TypeVar("TModelHFHubMixin", bound="ModelHFHubMixin")
 
 
-class PieModelHFHubMixin(PieBaseHFHubMixin):
+class ModelHFHubMixin(PieBaseHFHubMixin):
     config_name = CONFIG_NAME
     config_type_key = "model_type"
     weights_file_name = PYTORCH_WEIGHTS_NAME
-    """Implementation of [`PieBaseHFHubMixin`] to provide model Hub upload/download capabilities to
+    """Implementation of [`ModelHFHubMixin`] to provide model Hub upload/download capabilities to
     models.
 
     Example for a Pytorch model:
@@ -108,7 +108,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
 
     @classmethod
     def _from_pretrained(
-        cls: Type[TModel],
+        cls: Type[TModelHFHubMixin],
         *,
         model_id: str,
         revision: Optional[str],
@@ -122,7 +122,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         strict: bool = False,
         config: Optional[dict] = None,
         **kwargs,
-    ) -> TModel:
+    ) -> TModelHFHubMixin:
 
         model_file, remaining_kwargs = cls.retrieve_model_file(
             model_id=model_id,
@@ -144,7 +144,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         return model
 
 
-class Model(PieModelHFHubMixin, HyperparametersMixin, Registrable["Model"]):
+class Model(ModelHFHubMixin, HyperparametersMixin, Registrable["Model"]):
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
@@ -163,6 +163,6 @@ class Model(PieModelHFHubMixin, HyperparametersMixin, Registrable["Model"]):
         return config
 
 
-class AutoModel(PieModelHFHubMixin, Auto[Model]):
+class AutoModel(ModelHFHubMixin, Auto[Model]):
 
     BASE_CLASS = Model

--- a/src/pie_core/model.py
+++ b/src/pie_core/model.py
@@ -118,11 +118,24 @@ class ModelHFHubMixin(PieBaseHFHubMixin):
         resume_download: bool,
         local_files_only: bool,
         token: Union[str, bool, None],
-        map_location: str = "cpu",
-        strict: bool = False,
         config: Optional[dict] = None,
+        load_model_file: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> TModelHFHubMixin:
+
+        load_model_file_kwargs = load_model_file or {}
+        if "map_location" in kwargs:
+            map_location = kwargs.pop("map_location")
+            logger.warning(
+                f'map_location is deprecated. Use load_model_file=\\{"map_location": "{map_location}"\\} instead.'
+            )
+            load_model_file_kwargs["map_location"] = map_location
+        if "strict" in kwargs:
+            strict = kwargs.pop("strict")
+            logger.warning(
+                f'strict is deprecated. Use load_model_file=\\{"strict": {strict}\\} instead.'
+            )
+            load_model_file_kwargs["strict"] = strict
 
         model_file, remaining_kwargs = cls.retrieve_model_file(
             model_id=model_id,
@@ -136,10 +149,8 @@ class ModelHFHubMixin(PieBaseHFHubMixin):
             **kwargs,
         )
         model = cls.from_config(config=config or {}, **remaining_kwargs)
-
-        # TODO: map_location and strict are quite specific to PyTorch.
-        #  How to handle this in a more generic way?
-        model.load_model_file(model_file, map_location=map_location, strict=strict)
+        # load the model weights
+        model.load_model_file(model_file, **load_model_file_kwargs)
 
         return model
 

--- a/src/pie_core/model.py
+++ b/src/pie_core/model.py
@@ -1,13 +1,147 @@
 import logging
-from typing import Any, Dict
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union
 
+from huggingface_hub import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
+from huggingface_hub.file_download import hf_hub_download
 from pytorch_lightning.core.mixins import HyperparametersMixin
 
 from pie_core.auto import Auto
-from pie_core.hf_hub_mixin import PieModelHFHubMixin
+from pie_core.hf_hub_mixin import PieBaseHFHubMixin
 from pie_core.registrable import Registrable
 
 logger = logging.getLogger(__name__)
+
+TModel = TypeVar("TModel", bound="PieModelHFHubMixin")
+
+
+class PieModelHFHubMixin(PieBaseHFHubMixin):
+    config_name = CONFIG_NAME
+    config_type_key = "model_type"
+    weights_file_name = PYTORCH_WEIGHTS_NAME
+    """Implementation of [`PieBaseHFHubMixin`] to provide model Hub upload/download capabilities to
+    models.
+
+    Example for a Pytorch model:
+
+    ```python
+    >>> import torch
+    >>> import torch.nn as nn
+    >>> from pie_core import PieModelHFHubMixin
+
+
+    >>> class MyPytorchModel(nn.Module, PieModelHFHubMixin):
+    ...     def __init__(self):
+    ...         super().__init__()
+    ...         self.param = nn.Parameter(torch.rand(3, 4))
+    ...         self.linear = nn.Linear(4, 5)
+
+    ...     def forward(self, x):
+    ...         return self.linear(x + self.param)
+    ...
+    ...     def save_model_file(self, model_file: str) -> None:
+    ...         torch.save(self.state_dict(), model_file)
+    ...
+    ...     def load_model_file(
+    ...         self, model_file: str, map_location: str = "cpu", strict: bool = False
+    ...     ) -> None:
+    ...         state_dict = torch.load(model_file, map_location=torch.device(map_location))
+    ...         self.load_state_dict(state_dict, strict=strict)
+
+    >>> model = MyModel()
+
+    # Save model weights to local directory
+    >>> model.save_pretrained("my-awesome-model")
+
+    # Push model weights to the Hub
+    >>> model.push_to_hub("my-awesome-model")
+
+    # Download and initialize weights from the Hub
+    >>> model = MyModel.from_pretrained("username/my-awesome-model")
+    ```
+    """
+
+    def save_model_file(self, model_file: str) -> None:
+        """Save weights from a model to a local directory."""
+        raise NotImplementedError
+
+    def load_model_file(self, model_file: str, **kwargs) -> None:
+        """Load weights from a model file."""
+        raise NotImplementedError
+
+    def _save_pretrained(self, save_directory: Path) -> None:
+        """Save weights from a model to a local directory."""
+        self.save_model_file(str(save_directory / self.weights_file_name))
+
+    @classmethod
+    def retrieve_model_file(
+        cls,
+        model_id: str,
+        revision: Optional[str] = None,
+        cache_dir: Optional[Union[str, Path]] = None,
+        force_download: bool = False,
+        proxies: Optional[Dict] = None,
+        resume_download: bool = False,
+        local_files_only: bool = False,
+        token: Optional[Union[str, bool]] = None,
+        **remaining_kwargs,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Retrieve the model file from the Huggingface Hub or local directory."""
+        if os.path.isdir(model_id):
+            logger.info("Loading weights from local directory")
+            model_file = os.path.join(model_id, cls.weights_file_name)
+        else:
+            model_file = hf_hub_download(
+                repo_id=model_id,
+                filename=cls.weights_file_name,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                proxies=proxies,
+                resume_download=resume_download,
+                token=token,
+                local_files_only=local_files_only,
+            )
+
+        return model_file, remaining_kwargs
+
+    @classmethod
+    def _from_pretrained(
+        cls: Type[TModel],
+        *,
+        model_id: str,
+        revision: Optional[str],
+        cache_dir: Optional[Union[str, Path]],
+        force_download: bool,
+        proxies: Optional[Dict],
+        resume_download: bool,
+        local_files_only: bool,
+        token: Union[str, bool, None],
+        map_location: str = "cpu",
+        strict: bool = False,
+        config: Optional[dict] = None,
+        **kwargs,
+    ) -> TModel:
+
+        model_file, remaining_kwargs = cls.retrieve_model_file(
+            model_id=model_id,
+            revision=revision,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            proxies=proxies,
+            resume_download=resume_download,
+            local_files_only=local_files_only,
+            token=token,
+            **kwargs,
+        )
+        model = cls.from_config(config=config or {}, **remaining_kwargs)
+
+        # TODO: map_location and strict are quite specific to PyTorch.
+        #  How to handle this in a more generic way?
+        model.load_model_file(model_file, map_location=map_location, strict=strict)
+
+        return model
 
 
 class Model(PieModelHFHubMixin, HyperparametersMixin, Registrable["Model"]):

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -20,7 +20,7 @@ from tqdm import tqdm
 
 from pie_core.auto import Auto
 from pie_core.document import Annotation, Document
-from pie_core.hf_hub_mixin import PieTaskModuleHFHubMixin, TNestedBoolDict
+from pie_core.hf_hub_mixin import PieBaseHFHubMixin, TNestedBoolDict
 from pie_core.module_mixins import WithDocumentTypeMixin
 from pie_core.preparable import PreparableMixin
 from pie_core.registrable import Registrable
@@ -42,6 +42,11 @@ TaskOutput = TypeVar("TaskOutput")
 
 
 logger = logging.getLogger(__name__)
+
+
+class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
+    config_name = "taskmodule_config.json"
+    config_type_key = "taskmodule_type"
 
 
 class TaskModule(

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -66,8 +66,6 @@ class TaskModuleHFHubMixin(PieBaseHFHubMixin):
         resume_download: bool,
         local_files_only: bool,
         token: Union[str, bool, None],
-        map_location: str = "cpu",
-        strict: bool = False,
         config: Optional[dict] = None,
         **kwargs,
     ) -> TTaskModuleHFHubMixin:

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -2,6 +2,7 @@ import copy
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
+from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -43,15 +44,42 @@ TaskOutput = TypeVar("TaskOutput")
 
 logger = logging.getLogger(__name__)
 
+TTaskModuleHFHubMixin = TypeVar("TTaskModuleHFHubMixin", bound="TaskModuleHFHubMixin")
 
-class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
+
+class TaskModuleHFHubMixin(PieBaseHFHubMixin):
     config_name = "taskmodule_config.json"
     config_type_key = "taskmodule_type"
+
+    def _save_pretrained(self, save_directory) -> None:
+        return None
+
+    @classmethod
+    def _from_pretrained(
+        cls: Type[TTaskModuleHFHubMixin],
+        *,
+        model_id: str,
+        revision: Optional[str],
+        cache_dir: Optional[Union[str, Path]],
+        force_download: bool,
+        proxies: Optional[Dict],
+        resume_download: bool,
+        local_files_only: bool,
+        token: Union[str, bool, None],
+        map_location: str = "cpu",
+        strict: bool = False,
+        config: Optional[dict] = None,
+        **kwargs,
+    ) -> TTaskModuleHFHubMixin:
+
+        taskmodule = cls.from_config(config=config or {}, **kwargs)
+
+        return taskmodule
 
 
 class TaskModule(
     ABC,
-    PieTaskModuleHFHubMixin,
+    TaskModuleHFHubMixin,
     HyperparametersMixin,
     Registrable["TaskModule"],
     WithDocumentTypeMixin,
@@ -422,6 +450,6 @@ class TaskModule(
         return None
 
 
-class AutoTaskModule(PieTaskModuleHFHubMixin, Auto[TaskModule]):
+class AutoTaskModule(TaskModuleHFHubMixin, Auto[TaskModule]):
 
     BASE_CLASS = TaskModule


### PR DESCRIPTION
In detail:
- convert `PieBaseHFHubMixin.retrieve_config` to `.retrieve_config_file` which just returns the config file path, if available
- add `ModelHFHubMixin.retrieve_model_file` in a similar manner
- move `hf_hub_mixin.PieModelHFHubMixin` to `model.ModelHFHubMixin` (note the removed `PIE`)
- move `hf_hub_mixin.PieTaskModuleHFHubMixin` to `taskmodule.TaskModuleHFHubMixin` (note the removed `PIE`)
- move `hf_hub_mixin.AnnotationPipelineHFHubMixin` to `annotation_pipeline.AnnotationPipelineHFHubMixin`
- remove `AnnotationPipeline.from_pretrained`, but add `AnnotationPipelineHFHubMixin._from_pretrained` instead to align with model and taskmodule
- simplify `AnnotationPipelineHFHubMixin._from_pretrained` by using `from_pretrained` also for the taskmodule
- derive `AutoAnnotationPipeline` from `AnnotationPipelineHFHubMixin` (in analogy to model and taskmodule)
- add parameter `load_model_file` to `ModelHFHubMixin._from_pretrained`: 
    - gets passed as keyword arguments to `.load_model_file()`
    - log deprecation warnings if `map_location` or `strict` are passed directly (but still add them to `load_model_file`)

TL;DR:
 - `hf_hub_mixin` only contains `PieBaseHFHubMixin`
 - `model` / `taskmodule` / `annotation_pipeline` contain `ModelHFHubMixin` / `TaskModuleHFHubMixin` / `AnnotationPipelineHFHubMixin`, respectively
 - each of them defines `_save_pretrained` and `_from_pretrained` (`from_pretrained` is never touched)