### PR TITLE
add test for `utils.dictionary.dict_update_nested()`

### DIFF
--- a/src/pie_core/utils/dictionary.py
+++ b/src/pie_core/utils/dictionary.py
@@ -163,6 +163,31 @@ TNestedBoolDict = Union[bool, Dict[str, "TNestedBoolDict"]]
 def dict_update_nested(d: dict, u: dict, override: Optional[TNestedBoolDict] = None) -> None:
     """Update a dictionary with another dictionary, recursively.
 
+    Examples:
+        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        >>> u = {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+        >>> dict_update_nested(d, u, True)
+        >>> d == u ==  {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+        True
+
+        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        >>> u = {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+        >>> dict_update_nested(d, u, False)
+        >>> d == {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        True
+
+        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": {"f": 3}}}
+        >>> u = {"a": {"b": {"c": 4}, "e": 6}}
+        >>> dict_update_nested(d, u)
+        >>> d == {"a": {"b": {"c": 4, "d": 2}, "e": 6}}
+        True
+
+        >>> d = {"a": {"b": {"c": 1}, "d": {"e": 2}}}
+        >>> u = {"a": {"b": {"c": 3}, "d": {"e": 4}}}
+        >>> override = {"a": {"b": True, "d": False}}
+        >>> dict_update_nested(d, u, override)
+        >>> d == {"a": {"b": {"c": 3}, "d": {"e": 2}}}
+        True
     Args:
         d (`dict`):
             The original dictionary to update.
@@ -175,32 +200,6 @@ def dict_update_nested(d: dict, u: dict, override: Optional[TNestedBoolDict] = N
             If a dictionary, recursively merge the dictionaries, using the provided dictionary as the override.
     Returns:
         None
-
-    Examples:
-        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-        >>> u = {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
-        >>> dict_update_nested(d, u, True)
-        >>> d == u ==  {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
-        True
-
-        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-        >>> u = {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
-        >>> dict_update_nested(d, u, False)
-        >>> d == {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-        True
-
-        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-        >>> u = {"a": {"b": {"c": 4, "d": 5}}}
-        >>> dict_update_nested(d, u)
-        >>> d == {"a": {"b": {"c": 4, "d": 5}, "e": 3}}
-        True
-
-        >>> d = {"a": {"b": {"c": 1}, "d": {"e": 2}}}
-        >>> u = {"a": {"b": {"c": 3}, "d": {"e": 4}}}
-        >>> override = {"a": {"b": True, "d": False}}
-        >>> dict_update_nested(d, u, override)
-        >>> d == {"a": {"b": {"c": 3}, "d": {"e": 2}}}
-        True
     """
     if isinstance(override, bool):
         if override:

--- a/src/pie_core/utils/dictionary.py
+++ b/src/pie_core/utils/dictionary.py
@@ -210,20 +210,20 @@ def dict_update_nested(d: dict, u: dict, override: Optional[TNestedBoolDict] = N
     if override is None:
         override = {}
 
-    for k, v_u in u.items():
-        o = override.get(k)
+    for k_u, v_u in u.items():
+        o = override.get(k_u)
         # force override with new value
         if o is True:
-            d[k] = v_u
+            d[k_u] = v_u
         # force ignore the new value
         elif o is False:
             pass
         # both dicts, update nested
-        elif isinstance(v_u, dict) and isinstance(d.get(k), dict):
-            dict_update_nested(d[k], v_u, override=o)
+        elif isinstance(v_u, dict) and isinstance(d.get(k_u), dict):
+            dict_update_nested(d[k_u], v_u, override=o)
         # finally, just one is a dict, but the other is not
         else:
-            d[k] = v_u
+            d[k_u] = v_u
 
     overrides_not_in_update = set(override) - set(u)
     if len(overrides_not_in_update) > 0:

--- a/src/pie_core/utils/dictionary.py
+++ b/src/pie_core/utils/dictionary.py
@@ -175,6 +175,32 @@ def dict_update_nested(d: dict, u: dict, override: Optional[TNestedBoolDict] = N
             If a dictionary, recursively merge the dictionaries, using the provided dictionary as the override.
     Returns:
         None
+
+    Examples:
+        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        >>> u = {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
+        >>> dict_update_nested(d, u, True)
+        >>> d == u ==  {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
+        True
+
+        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        >>> u = {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
+        >>> dict_update_nested(d, u, False)
+        >>> d == {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        True
+
+        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        >>> u = {"a": {"b": {"c": 4, "d": 5}}}
+        >>> dict_update_nested(d, u)
+        >>> d == {"a": {"b": {"c": 4, "d": 5}, "e": 3}}
+        True
+
+        >>> d = {"a": {"b": {"c": 1}, "d": {"e": 2}}}
+        >>> u = {"a": {"b": {"c": 3}, "d": {"e": 4}}}
+        >>> override = {"a": {"b": True, "d": False}}
+        >>> dict_update_nested(d, u, override)
+        >>> d == {"a": {"b": {"c": 3}, "d": {"e": 2}}}
+        True
     """
     if isinstance(override, bool):
         if override:

--- a/src/pie_core/utils/dictionary.py
+++ b/src/pie_core/utils/dictionary.py
@@ -217,3 +217,10 @@ def dict_update_nested(d: dict, u: dict, override: Optional[TNestedBoolDict] = N
             dict_update_nested(d[k], v, override=override.get(k))
         else:
             d[k] = v
+
+    overrides_not_in_update = set(override) - set(u)
+    if len(overrides_not_in_update) > 0:
+        raise ValueError(
+            f"Cannot merge {u} into {d} with override={override} because the "
+            f"override contains keys not in the update: {sorted(overrides_not_in_update)}"
+        )

--- a/src/pie_core/utils/dictionary.py
+++ b/src/pie_core/utils/dictionary.py
@@ -210,13 +210,20 @@ def dict_update_nested(d: dict, u: dict, override: Optional[TNestedBoolDict] = N
     if override is None:
         override = {}
 
-    for k, v in u.items():
-        if isinstance(v, dict) and k in d:
-            if not isinstance(d[k], dict):
-                raise ValueError(f"Cannot merge {d[k]} and {v} because {d[k]} is not a dict.")
-            dict_update_nested(d[k], v, override=override.get(k))
+    for k, v_u in u.items():
+        o = override.get(k)
+        # force override with new value
+        if o is True:
+            d[k] = v_u
+        # force ignore the new value
+        elif o is False:
+            pass
+        # both dicts, update nested
+        elif isinstance(v_u, dict) and isinstance(d.get(k), dict):
+            dict_update_nested(d[k], v_u, override=o)
+        # finally, just one is a dict, but the other is not
         else:
-            d[k] = v
+            d[k] = v_u
 
     overrides_not_in_update = set(override) - set(u)
     if len(overrides_not_in_update) > 0:

--- a/src/pie_core/utils/dictionary.py
+++ b/src/pie_core/utils/dictionary.py
@@ -218,10 +218,10 @@ def dict_update_nested(d: dict, u: dict, override: Optional[TNestedBoolDict] = N
         # force ignore the new value
         elif o is False:
             pass
-        # both dicts, update nested
+        # both dicts: update nested
         elif isinstance(v_u, dict) and isinstance(d.get(k_u), dict):
             dict_update_nested(d[k_u], v_u, override=o)
-        # finally, just one is a dict, but the other is not
+        # override (or set if did not exist) with new value
         else:
             d[k_u] = v_u
 

--- a/src/pie_core/utils/dictionary.py
+++ b/src/pie_core/utils/dictionary.py
@@ -164,29 +164,38 @@ def dict_update_nested(d: dict, u: dict, override: Optional[TNestedBoolDict] = N
     """Update a dictionary with another dictionary, recursively.
 
     Examples:
-        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-        >>> u = {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+
+        Override=True:
+
+        >>> d = {"a": 1}
+        >>> u = {"b": 2}
         >>> dict_update_nested(d, u, True)
-        >>> d == u ==  {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+        >>> d == u == {"b": 2}
         True
 
-        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-        >>> u = {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+        override=False:
+
+        >>> d = {"a": 1}
+        >>> u = {"b": 2}
         >>> dict_update_nested(d, u, False)
-        >>> d == {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+        >>> d == {"a": 1}
         True
 
-        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": {"f": 3}}}
-        >>> u = {"a": {"b": {"c": 4}, "e": 6}}
+        Recursively update:
+
+        >>> d = {"a": {"b": {"c": 1, "d": 2}, "e": {"f": 3}}, "g": 4       }
+        >>> u = {"a": {"b": {"c": 5        }, "e": 6       }, "g": {"h": 7}}
         >>> dict_update_nested(d, u)
-        >>> d == {"a": {"b": {"c": 4, "d": 2}, "e": 6}}
+        >>> d == {"a": {"b": {"c": 5, "d": 2}, "e": 6       }, "g": {"h": 7}}
         True
 
-        >>> d = {"a": {"b": {"c": 1}, "d": {"e": 2}}}
-        >>> u = {"a": {"b": {"c": 3}, "d": {"e": 4}}}
+        Override dict:
+
+        >>> d = {"a": {"b": {"c": 1}, "d": {"e": 2}}, "f": 3}
+        >>> u = {"a": {"b": {"c": 3}, "d": {"e": 4}}, "f": 4}
         >>> override = {"a": {"b": True, "d": False}}
         >>> dict_update_nested(d, u, override)
-        >>> d == {"a": {"b": {"c": 3}, "d": {"e": 2}}}
+        >>> d == {"a": {"b": {"c": 3}, "d": {"e": 2}}, "f": 4}
         True
     Args:
         d (`dict`):

--- a/tests/test_utils/test_dictionary.py
+++ b/tests/test_utils/test_dictionary.py
@@ -178,19 +178,19 @@ def test_dict_update_nested():
 
     # simple cases from docstring
     d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-    u = {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
+    u = {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
     dict_update_nested(d, u, True)
-    assert d == u == {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
+    assert d == u == {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
 
     d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-    u = {"a": {"b": {"c": 4, "d": 5}, "f": 6}}
+    u = {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
     dict_update_nested(d, u, False)
     assert d == {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
 
-    d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-    u = {"a": {"b": {"c": 4, "d": 5}}}
+    d = {"a": {"b": {"c": 1, "d": 2}, "e": {"f": 3}}}
+    u = {"a": {"b": {"c": 4}, "e": 6}}
     dict_update_nested(d, u)
-    assert d == {"a": {"b": {"c": 4, "d": 5}, "e": 3}}
+    assert d == {"a": {"b": {"c": 4, "d": 2}, "e": 6}}
 
     d = {"a": {"b": {"c": 1}, "d": {"e": 2}}}
     u = {"a": {"b": {"c": 3}, "d": {"e": 4}}}
@@ -199,12 +199,12 @@ def test_dict_update_nested():
     assert d == {"a": {"b": {"c": 3}, "d": {"e": 2}}}
 
     # Override dicts
-    # 'd' override ignored, override value is used only if merging values are both dicts.
+    # Multiple overrides; override for non-dict value
     d = {"a": {"b": {"c": 1}}, "d": 2, "e": 3}
     u = {"a": {"b": {"c": 3}}, "d": 4, "f": 5}
     override = {"a": {"b": True}, "d": False}
     dict_update_nested(d, u, override)
-    assert d == {"a": {"b": {"c": 3}}, "d": 4, "e": 3, "f": 5}
+    assert d == {"a": {"b": {"c": 3}}, "d": 2, "e": 3, "f": 5}
 
     # More nested override
     d = {"a": {"b": {"c": {"d": 1}}}}
@@ -216,23 +216,18 @@ def test_dict_update_nested():
     # Override for multiple targets
     d = {"a": {"b": {"c": {"d": 1}, "e": {"f": 2}}}}
     u = {"a": {"b": {"c": {"d": 3}, "e": {"f": 4}}}}
-    override = {"a": {"b": {"c": True, "e": False}}}
+    override = {"a": {"b": {"c": True, "e": {"f": False}}}}
     dict_update_nested(d, u, override)
     assert d == {"a": {"b": {"c": {"d": 3}, "e": {"f": 2}}}}
 
-    # Override contains a target not contained in any of dicts (should not impact anything)
-    d = {"a": {"b": {"c": {"d": 1}, "e": {"f": 2}}}}
-    u = {"a": {"b": {"c": {"d": 3}, "e": {"f": 4}}}}
-    override = {"g": True, "h": False}
-    dict_update_nested(d, u, override)
-    assert d == {"a": {"b": {"c": {"d": 3}, "e": {"f": 4}}}}
-
-    # Update not-dict value with dict value
+    # Override target not in update
+    d = {"a": {"b": 1}}
+    u = {"a": {"c": 1}}
+    override = {"a": {"b": True}}
     with pytest.raises(ValueError) as excinfo:
-        dict_update_nested({"a": 1}, {"a": {"b": 1}})
-    assert str(excinfo.value) == "Cannot merge 1 and {'b': 1} because 1 is not a dict."
-
-    # !Vice-versa is not checked and dict will be updated
-    # with pytest.raises(ValueError) as excinfo:
-    #     dict_update_nested({"a": {"b": 1}}, {"a": 1})
-    # assert str(excinfo.value) == "Cannot merge {'b': 1} and 1 because 1 is not a dict."
+        dict_update_nested(d, u, override)
+    assert (
+        str(excinfo.value)
+        == "Cannot merge {'c': 1} into {'b': 1, 'c': 1} with override={'b': True} "
+        "because the override contains keys not in the update: ['b']"
+    )

--- a/tests/test_utils/test_dictionary.py
+++ b/tests/test_utils/test_dictionary.py
@@ -177,26 +177,26 @@ def test_unflatten_dict_s_multiple_roots():
 def test_dict_update_nested():
 
     # simple cases from docstring
-    d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-    u = {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+    d = {"a": 1}
+    u = {"b": 2}
     dict_update_nested(d, u, True)
-    assert d == u == {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+    d == u == {"b": 2}
 
-    d = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
-    u = {"a": {"b": {"c": 4, "d": 5}, "f": {"g": 6}}}
+    d = {"a": 1}
+    u = {"b": 2}
     dict_update_nested(d, u, False)
-    assert d == {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+    d == u == {"a": 1}
 
-    d = {"a": {"b": {"c": 1, "d": 2}, "e": {"f": 3}}}
-    u = {"a": {"b": {"c": 4}, "e": 6}}
+    d = {"a": {"b": {"c": 1, "d": 2}, "e": {"f": 3}}, "g": 4}
+    u = {"a": {"b": {"c": 5}, "e": 6}, "g": {"h": 7}}
     dict_update_nested(d, u)
-    assert d == {"a": {"b": {"c": 4, "d": 2}, "e": 6}}
+    assert d == {"a": {"b": {"c": 5, "d": 2}, "e": 6}, "g": {"h": 7}}
 
-    d = {"a": {"b": {"c": 1}, "d": {"e": 2}}}
-    u = {"a": {"b": {"c": 3}, "d": {"e": 4}}}
+    d = {"a": {"b": {"c": 1}, "d": {"e": 2}}, "f": 3}
+    u = {"a": {"b": {"c": 3}, "d": {"e": 4}}, "f": 4}
     override = {"a": {"b": True, "d": False}}
     dict_update_nested(d, u, override)
-    assert d == {"a": {"b": {"c": 3}, "d": {"e": 2}}}
+    assert d == {"a": {"b": {"c": 3}, "d": {"e": 2}}, "f": 4}
 
     # Override dicts
     # Multiple overrides; override for non-dict value

--- a/tests/test_utils/test_dictionary.py
+++ b/tests/test_utils/test_dictionary.py
@@ -1,7 +1,10 @@
+from copy import deepcopy
+
 import pytest
 
 from pie_core.utils.dictionary import (
     dict_of_lists2list_of_dicts,
+    dict_update_nested,
     flatten_dict,
     flatten_dict_s,
     list_of_dicts2dict_of_lists,
@@ -171,3 +174,33 @@ def test_unflatten_dict_s_multiple_roots():
         str(excinfo.value)
         == "Conflict at path ('a',): trying to overwrite existing dict with a non-dict value."
     )
+
+
+def test_dict_update_nested():
+
+    dct = {"a": {"b": 1}, "c": 2, "d": 3}
+    u = {"a": {"b": 4}, "c": 5, "e": 6}
+
+    d = deepcopy(dct)
+    dict_update_nested(d, u)
+    assert d == {"a": {"b": 4}, "c": 5, "d": 3, "e": 6}
+
+    d = deepcopy(dct)
+    dict_update_nested(d, u, True)
+    assert d == u
+
+    d = deepcopy(dct)
+    dict_update_nested(d, u, False)
+    assert d == dct
+
+    d = deepcopy(dct)
+    dict_update_nested(d, u, {"a": True})
+    assert d == {"a": {"b": 4}, "c": 5, "d": 3, "e": 6}
+
+    d = deepcopy(dct)
+    dict_update_nested(d, u, {"a": False})
+    assert d == {"a": {"b": 1}, "c": 5, "d": 3, "e": 6}
+
+    with pytest.raises(ValueError) as excinfo:
+        dict_update_nested({"a": 1}, {"a": {"b": 1}})
+    assert str(excinfo.value) == "Cannot merge 1 and {'b': 1} because 1 is not a dict."


### PR DESCRIPTION
This PR:
- Adds tests for 'dict_update_nested()' (See #32 )
- Adds usage examples to the docstring.
- Adds support for overriding any key in update dict, not only if value is a dict.
- Removes exception when updating a value of type dict with a non-dict value.
- Adds exception thrown if `override` contains any keys not present in update dict.