### PR TITLE
implement `EncodingMetric` interface

### DIFF
--- a/src/pie_core/__init__.py
+++ b/src/pie_core/__init__.py
@@ -1,7 +1,7 @@
 from pie_core.annotation_pipeline import AnnotationPipeline, AutoAnnotationPipeline
 from pie_core.auto import Auto
 from pie_core.document import Annotation, AnnotationLayer, Document, annotation_field
-from pie_core.metric import DocumentMetric, ModelMetric
+from pie_core.metric import DocumentMetric, EncodingMetric
 from pie_core.model import AutoModel, Model
 from pie_core.module_mixins import (
     EnterDatasetDictMixin,

--- a/src/pie_core/__init__.py
+++ b/src/pie_core/__init__.py
@@ -1,7 +1,7 @@
 from pie_core.annotation_pipeline import AnnotationPipeline, AutoAnnotationPipeline
 from pie_core.auto import Auto
 from pie_core.document import Annotation, AnnotationLayer, Document, annotation_field
-from pie_core.metric import DocumentMetric
+from pie_core.metric import DocumentMetric, ModelMetric
 from pie_core.model import AutoModel, Model
 from pie_core.module_mixins import (
     EnterDatasetDictMixin,

--- a/src/pie_core/metric.py
+++ b/src/pie_core/metric.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Iterable, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, Union
 
 from pie_core.document import Document
 from pie_core.module_mixins import WithDocumentTypeMixin
@@ -73,3 +73,26 @@ class DocumentMetric(ABC, WithDocumentTypeMixin, Generic[T]):
     def current_split(self) -> Optional[str]:
         """The current split that is being processed."""
         return self._current_split
+
+
+TPredictions = TypeVar("TPredictions")
+TTargets = TypeVar("TTargets")
+
+
+class ModelMetric(Generic[TPredictions, TTargets], ABC):
+    """This defines the interface for a model metric.
+
+    It loosely follows the Metric API of torchmetrics.
+    """
+
+    def reset(self) -> None:
+        """Any reset logic that needs to be performed before the metric is called again."""
+        pass
+
+    def update(self, predictions: TPredictions, targets: TTargets) -> None:
+        """This method is called to update the metric with the predictions and targets."""
+        pass
+
+    def compute(self) -> Any:
+        """This method is called to compute the metric."""
+        pass

--- a/src/pie_core/metric.py
+++ b/src/pie_core/metric.py
@@ -79,8 +79,9 @@ TPredictions = TypeVar("TPredictions")
 TTargets = TypeVar("TTargets")
 
 
-class ModelMetric(Generic[TPredictions, TTargets], ABC):
-    """This defines the interface for a model metric.
+class EncodingMetric(Generic[TPredictions, TTargets], ABC):
+    """This defines the interface for a metric that is used to compute score(s) based on (model)
+    predictions and targets (probably in batch form).
 
     It loosely follows the Metric API of torchmetrics.
     """

--- a/src/pie_core/metric.py
+++ b/src/pie_core/metric.py
@@ -87,13 +87,13 @@ class EncodingMetric(Generic[TPredictions, TTargets], ABC):
     """
 
     def reset(self) -> None:
-        """Any reset logic that needs to be performed before the metric is called again."""
+        """Any (state) reset logic that needs to be performed before the metric is called again."""
         pass
 
     def update(self, predictions: TPredictions, targets: TTargets) -> None:
-        """This method is called to update the metric with the predictions and targets."""
+        """This method is called to update the metric state with the predictions and targets."""
         pass
 
     def compute(self) -> Any:
-        """This method is called to compute the metric."""
+        """This method is called to compute the metric value(s) from the metric state."""
         pass

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 from pie_core.auto import Auto
 from pie_core.document import Annotation, Document
 from pie_core.hf_hub_mixin import PieBaseHFHubMixin, TNestedBoolDict
-from pie_core.metric import ModelMetric
+from pie_core.metric import EncodingMetric
 from pie_core.module_mixins import WithDocumentTypeMixin
 from pie_core.preparable import PreparableMixin
 from pie_core.registrable import Registrable
@@ -447,10 +447,10 @@ class TaskModule(
 
     def configure_model_metric(
         self, stage: str
-    ) -> Optional[ModelMetric[ModelBatchOutput, TargetBatchEncoding]]:
+    ) -> Optional[EncodingMetric[ModelBatchOutput, TargetBatchEncoding]]:
         logger.warning(
             f"TaskModule {self.__class__.__name__} does not implement a model metric. "
-            f"Override configure_model_metric(stage) to configure a metric for stage '{stage}'."
+            f"Override configure_model_metric(stage: str) to configure a metric for stage '{stage}'."
         )
         return None
 

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -448,6 +448,16 @@ class TaskModule(
     def configure_model_metric(
         self, stage: str
     ) -> Optional[EncodingMetric[ModelBatchOutput, TargetBatchEncoding]]:
+        """Configure the model metric. This method is called by the model to configure the metric
+        for the given stage. It will be used to compute the metric score(s) based on the model
+        predictions and targets.
+
+        Args:
+            stage: The stage for which the metric is configured, e.g., "train", "val", "test".
+
+        Returns:
+            The metric for the given stage.
+        """
         logger.warning(
             f"TaskModule {self.__class__.__name__} does not implement a model metric. "
             f"Override configure_model_metric(stage: str) to configure a metric for stage '{stage}'."

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -38,8 +38,9 @@ TargetEncoding = TypeVar("TargetEncoding")
 # TaskEncoding: defined below
 InputBatchEncoding = TypeVar("InputBatchEncoding")
 TargetBatchEncoding = TypeVar("TargetBatchEncoding")
-# TaskBatchEncoding = TypeVar("TaskBatchEncoding")
 # TaskBatchEncoding: TypeAlias = Tuple[InputBatchEncoding, Optional[TargetBatchEncoding]]
+# TODO: remove in favor of InputBatchEncoding and TargetBatchEncoding
+TaskBatchEncoding = TypeVar("TaskBatchEncoding")
 # ModelBatchEncoding: defined in models
 ModelBatchOutput = TypeVar("ModelBatchOutput")
 TaskOutput = TypeVar("TaskOutput")
@@ -89,8 +90,8 @@ class TaskModule(
         DocumentType,
         InputEncoding,
         TargetEncoding,
-        InputBatchEncoding,
-        TargetBatchEncoding,
+        # TODO: replace with InputBatchEncoding and TargetBatchEncoding
+        TaskBatchEncoding,
         ModelBatchOutput,
         TaskOutput,
     ],

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -442,7 +442,7 @@ class TaskModule(
     @abstractmethod
     def collate(
         self, task_encodings: Sequence[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]]
-    ) -> Tuple[InputBatchEncoding, Optional[TargetBatchEncoding]]:
+    ) -> TaskBatchEncoding:
         pass
 
     def configure_model_metric(


### PR DESCRIPTION
to not rely on `Metric` from `torchmetrics` anymore (part two of #52)