### PR TITLE
don't derive `Model` from `HyperparametersMixin`

### DIFF
--- a/src/pie_core/auto.py
+++ b/src/pie_core/auto.py
@@ -3,6 +3,8 @@ from typing import Generic, Type, TypeVar
 from pie_core.hf_hub_mixin import PieBaseHFHubMixin
 from pie_core.registrable import Registrable
 
+# This is a workaround because T needs to be bound to the intersection of
+# Registrable and PieBaseHFHubMixin which is not possible in Python 3.9
 T = TypeVar("T", bound="Auto")
 
 

--- a/src/pie_core/model.py
+++ b/src/pie_core/model.py
@@ -155,10 +155,10 @@ class ModelHFHubMixin(PieBaseHFHubMixin):
         return model
 
 
-class Model(ModelHFHubMixin, HyperparametersMixin, Registrable["Model"]):
+class Model(ModelHFHubMixin, Registrable["Model"]):
 
     def _config(self) -> Dict[str, Any]:
-        config = super()._config() or {}
+        config = super().config
         if self.has_base_class():
             config[self.config_type_key] = self.base_class().name_for_object_class(self)
         else:
@@ -169,11 +169,11 @@ class Model(ModelHFHubMixin, HyperparametersMixin, Registrable["Model"]):
                 " @Model.register() or @Model.register(name='...') to register it at as a Model"
                 " which will allow to load it via AutoModel."
             )
-        # add all hparams
-        config.update(self.hparams)
+
         return config
 
 
-class AutoModel(ModelHFHubMixin, Auto[Model]):
+# ignore the typing error, see T in auto.py for details
+class AutoModel(ModelHFHubMixin, Auto[Model]):  # type: ignore
 
     BASE_CLASS = Model

--- a/src/pie_core/model.py
+++ b/src/pie_core/model.py
@@ -158,7 +158,7 @@ class ModelHFHubMixin(PieBaseHFHubMixin):
 class Model(ModelHFHubMixin, Registrable["Model"]):
 
     def _config(self) -> Dict[str, Any]:
-        config = super().config
+        config = super()._config() or {}
         if self.has_base_class():
             config[self.config_type_key] = self.base_class().name_for_object_class(self)
         else:


### PR DESCRIPTION
This remove the hparams from the config. This should be handled in more downstream such as in `PyTorchIEModel` to avoid conflicts.

context: #56

In theory this is breaking, but the only user is https://github.com/ArneBinder/pytorch-ie/pull/456 where we already handle this.