### PR TITLE
revert: swapping parent classes if `Auto`

### DIFF
--- a/src/pie_core/auto.py
+++ b/src/pie_core/auto.py
@@ -11,7 +11,7 @@ class RegistrableBaseHFHubProtocol(RegistrableProtocol, HFHubProtocol, Protocol)
 T = TypeVar("T", bound=RegistrableBaseHFHubProtocol)
 
 
-class Auto(Registrable[T], HFHubMixin, Generic[T]):
+class Auto(HFHubMixin, Registrable[T], Generic[T]):
 
     @classmethod
     def from_config(cls, config: dict, **kwargs) -> T:  # type: ignore


### PR DESCRIPTION
This fixes a regression introduced in #63. Error detected via pytorch-ie tests:
```
class AutoPyTorchIEModel(Model, Auto[PyTorchIEModel]):
../../miniconda3/lib/python3.9/abc.py:106: in __new__
cls = super().__new__(mcls, name, bases, namespace, **kwargs)
E   TypeError: Cannot create a consistent method resolution
E   order (MRO) for bases HFHubMixin, Registrable
```
