### PR TITLE
fix multi inheritance for mixins

### DIFF
--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -360,7 +360,10 @@ class HFHubProtocol(Protocol):
 class HFHubMixin(HFHubProtocol):
 
     def __init__(self, *args, is_from_pretrained: bool = False, **kwargs):
-        super().__init__(*args, **kwargs)
+        # skip the __init__ of HFHubProtocol: this would interrupt the
+        # constructor chain and disallow passing the args and kwargs to
+        # any other class in the case of multiple inheritance
+        super(HFHubProtocol, self).__init__(*args, **kwargs)
         self._is_from_pretrained = is_from_pretrained
 
     @property

--- a/src/pie_core/hparams_mixin.py
+++ b/src/pie_core/hparams_mixin.py
@@ -87,8 +87,8 @@ _given_hyperparameters: ContextVar = ContextVar("_given_hyperparameters", defaul
 class PieHyperparametersMixin:
     __jit_unused_properties__: list[str] = ["hparams", "hparams_initial"]
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self._log_hyperparams = False
 
     def save_hyperparameters(

--- a/src/pie_core/registrable.py
+++ b/src/pie_core/registrable.py
@@ -91,4 +91,8 @@ class Registrable(RegistrableProtocol[T]):
     a dictionary mapping class names to classes.
     """
 
-    pass
+    def __init__(self, *args, **kwargs):
+        # skip the __init__ of RegistrableProtocol: this would interrupt the
+        # constructor chain and disallow passing the args and kwargs to
+        # any other class in the case of multiple inheritance
+        super(RegistrableProtocol, self).__init__(*args, **kwargs)


### PR DESCRIPTION
This fixes another regression introduced in #63 which caused problems in downstream project (https://github.com/ArneBinder/pytorch-ie/pull/456). With this fix, mixins should be combinable as before and handle passing of constructor parameters again as expected.

Not really caused by #63, but we also adjust `PieHyperparametersMixin` to pass remaining arguments to the next constructor.