### PR TITLE
remove pass-through kwargs from `HFHubProtocol.retrieve_config_file`

### DIFF
--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -84,7 +84,7 @@ class AnnotationPipelineHFHubMixin(HFHubMixin):
         else:
             # otherwise:
             # 1. try to retrieve the taskmodule config file
-            taskmodule_config_file, _ = cls.auto_taskmodule_class.retrieve_config_file(
+            taskmodule_config_file = cls.auto_taskmodule_class.retrieve_config_file(
                 model_id=model_id,
                 force_download=force_download,
                 resume_download=resume_download,

--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -102,8 +102,7 @@ class HFHubProtocol(Protocol):
         local_files_only: bool = False,
         revision: Optional[str] = None,
         fail_silently: bool = False,
-        **remaining_kwargs,
-    ) -> Tuple[Optional[str], Dict[str, Any]]:
+    ) -> Optional[str]:
         """Retrieve the configuration file from the Huggingface Hub or local directory.
 
         Returns None if the config file is not found.
@@ -132,7 +131,7 @@ class HFHubProtocol(Protocol):
                 if not fail_silently:
                     logger.warning(f"{cls.config_name} not found in HuggingFace Hub.")
 
-        return config_file, remaining_kwargs
+        return config_file
 
     @classmethod
     @validate_hf_hub_args
@@ -179,7 +178,7 @@ class HFHubProtocol(Protocol):
         """
         model_id = pretrained_model_name_or_path
 
-        config_file, _ = cls.retrieve_config_file(
+        config_file = cls.retrieve_config_file(
             model_id=model_id,
             revision=revision,
             cache_dir=cache_dir,

--- a/tests/test_hf_hub_mixin.py
+++ b/tests/test_hf_hub_mixin.py
@@ -170,7 +170,7 @@ def test_save_pretrained_push_to_hub_no_repo_id(hf_hub_object, caplog, tmp_path,
 
 
 def test_retrieve_config_file_local():
-    path_to_config, kwargs = HFHubObject.retrieve_config_file(PRETRAINED_PATH)
+    path_to_config = HFHubObject.retrieve_config_file(PRETRAINED_PATH)
     assert path_to_config is not None
     assert path_to_config == str(PRETRAINED_PATH / "hf_hub_config.json")
 
@@ -184,7 +184,7 @@ def test_retrieve_config_file_local_wrong_path(caplog, tmp_path):
 
 
 def test_retrieve_config_file_hf():
-    path_to_config, kwargs = HFHubObject.retrieve_config_file(HF_PATH)
+    path_to_config = HFHubObject.retrieve_config_file(HF_PATH)
     assert path_to_config is not None
     assert Path(path_to_config).is_file()
 


### PR DESCRIPTION
This functionality is not used, so we remove it to simplify the code.