### PR TITLE
modernize `huggingface_hub` usage

### DIFF
--- a/src/pie_core/annotation_pipeline.py
+++ b/src/pie_core/annotation_pipeline.py
@@ -13,6 +13,8 @@ from typing import (
     overload,
 )
 
+from huggingface_hub.constants import DEFAULT_ETAG_TIMEOUT
+
 from pie_core.auto import Auto
 from pie_core.document import Document
 from pie_core.hf_hub_mixin import HFHubMixin
@@ -43,13 +45,21 @@ class AnnotationPipelineHFHubMixin(HFHubMixin):
         cls: Type[TAnnotationPipelineHFHubMixin],
         *,
         model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Union[str, bool, None],
+        subfolder: Optional[str] = None,
+        repo_type: Optional[str] = None,
+        revision: Optional[str] = None,
+        library_name: Optional[str] = None,
+        library_version: Optional[str] = None,
+        cache_dir: Union[str, Path, None] = None,
+        local_dir: Union[str, Path, None] = None,
+        user_agent: Union[Dict, str, None] = None,
+        force_download: bool = False,
+        proxies: Optional[Dict] = None,
+        etag_timeout: float = DEFAULT_ETAG_TIMEOUT,
+        token: Union[bool, str, None] = None,
+        local_files_only: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        endpoint: Optional[str] = None,
         config: Optional[dict] = None,
         **kwargs,
     ) -> TAnnotationPipelineHFHubMixin:
@@ -70,11 +80,21 @@ class AnnotationPipelineHFHubMixin(HFHubMixin):
             # otherwise, create a new Model instance via AutoModel
             model = cls.auto_model_class.from_pretrained(
                 pretrained_model_name_or_path=model_id,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
+                subfolder=subfolder,
+                repo_type=repo_type,
+                revision=revision,
+                library_name=library_name,
+                library_version=library_version,
                 cache_dir=cache_dir,
+                local_dir=local_dir,
+                user_agent=user_agent,
+                force_download=force_download,
+                proxies=proxies,
+                etag_timeout=etag_timeout,
+                token=token,
                 local_files_only=local_files_only,
+                headers=headers,
+                endpoint=endpoint,
                 **(model_or_model_kwargs or {}),
             )
 
@@ -86,21 +106,41 @@ class AnnotationPipelineHFHubMixin(HFHubMixin):
             # 1. try to retrieve the taskmodule config file
             taskmodule_config_file = cls.auto_taskmodule_class.retrieve_config_file(
                 model_id=model_id,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
+                subfolder=subfolder,
+                repo_type=repo_type,
+                revision=revision,
+                library_name=library_name,
+                library_version=library_version,
                 cache_dir=cache_dir,
+                local_dir=local_dir,
+                user_agent=user_agent,
+                force_download=force_download,
+                proxies=proxies,
+                etag_timeout=etag_timeout,
+                token=token,
                 local_files_only=local_files_only,
+                headers=headers,
+                endpoint=endpoint,
             )
             # 2. If the taskmodule config file is found, load the taskmodule via from_pretrained()
             if taskmodule_config_file is not None:
                 taskmodule = cls.auto_taskmodule_class.from_pretrained(
                     pretrained_model_name_or_path=model_id,
-                    force_download=force_download,
-                    resume_download=resume_download,
-                    proxies=proxies,
+                    subfolder=subfolder,
+                    repo_type=repo_type,
+                    revision=revision,
+                    library_name=library_name,
+                    library_version=library_version,
                     cache_dir=cache_dir,
+                    local_dir=local_dir,
+                    user_agent=user_agent,
+                    force_download=force_download,
+                    proxies=proxies,
+                    etag_timeout=etag_timeout,
+                    token=token,
                     local_files_only=local_files_only,
+                    headers=headers,
+                    endpoint=endpoint,
                     **(taskmodule_or_taskmodule_kwargs or {}),
                 )
             # 3. Otherwise, do not load a taskmodule.

--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Optional, Protocol, Type, TypeVar, Union
 
 import requests
 from huggingface_hub.constants import DEFAULT_ETAG_TIMEOUT

--- a/src/pie_core/hf_hub_mixin.py
+++ b/src/pie_core/hf_hub_mixin.py
@@ -304,47 +304,27 @@ class HFHubProtocol(Protocol):
         repo_id: str,
         *,
         config: Optional[dict] = None,
-        commit_message: str = "Push model using huggingface_hub.",
-        private: bool = False,
         api_endpoint: Optional[str] = None,
-        token: Optional[str] = None,
-        branch: Optional[str] = None,
-        create_pr: Optional[bool] = None,
-        allow_patterns: Optional[Union[List[str], str]] = None,
-        ignore_patterns: Optional[Union[List[str], str]] = None,
-        delete_patterns: Optional[Union[List[str], str]] = None,
+        private: bool = False,
+        token: Union[bool, str, None] = None,
+        **upload_folder_kwargs,
     ) -> str:
         """Upload model checkpoint to the Hub.
 
-        Use `allow_patterns` and `ignore_patterns` to precisely filter which files should be pushed to the hub. Use
-        `delete_patterns` to delete existing remote files in the same commit. See [`upload_folder`] reference for more
-        details.
-
+        See [`upload_folder`] reference for more details.
 
         Args:
             repo_id (`str`):
                 ID of the repository to push to (example: `"username/my-model"`).
             config (`dict`, *optional*):
                 Configuration object to be saved alongside the model weights.
-            commit_message (`str`, *optional*):
-                Message to commit while pushing.
-            private (`bool`, *optional*, defaults to `False`):
-                Whether the repository created should be private.
             api_endpoint (`str`, *optional*):
                 The API endpoint to use when pushing the model to the hub.
+            private (`bool`, *optional*, defaults to `False`):
+                Whether the repository created should be private.
             token (`str`, *optional*):
                 The token to use as HTTP bearer authorization for remote files. By default, it will use the token
                 cached when running `huggingface-cli login`.
-            branch (`str`, *optional*):
-                The git branch on which to push the model. This defaults to `"main"`.
-            create_pr (`boolean`, *optional*):
-                Whether or not to create a Pull Request from `branch` with that commit. Defaults to `False`.
-            allow_patterns (`List[str]` or `str`, *optional*):
-                If provided, only files matching at least one pattern are pushed.
-            ignore_patterns (`List[str]` or `str`, *optional*):
-                If provided, files matching any of the patterns are not pushed.
-            delete_patterns (`List[str]` or `str`, *optional*):
-                If provided, remote files matching any of the patterns will be deleted from the repo.
 
         Returns:
             The url of the commit of your model in the given repository.
@@ -360,12 +340,7 @@ class HFHubProtocol(Protocol):
                 repo_id=repo_id,
                 repo_type="model",
                 folder_path=saved_path,
-                commit_message=commit_message,
-                revision=branch,
-                create_pr=create_pr,
-                allow_patterns=allow_patterns,
-                ignore_patterns=ignore_patterns,
-                delete_patterns=delete_patterns,
+                **upload_folder_kwargs,
             )
 
     @classmethod

--- a/src/pie_core/model.py
+++ b/src/pie_core/model.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union
 
+from huggingface_hub.constants import DEFAULT_ETAG_TIMEOUT
 from huggingface_hub.file_download import hf_hub_download
 
 from pie_core.auto import Auto
@@ -77,13 +78,7 @@ class ModelHFHubMixin(HFHubMixin):
     def retrieve_model_file(
         cls,
         model_id: str,
-        revision: Optional[str] = None,
-        cache_dir: Optional[Union[str, Path]] = None,
-        force_download: bool = False,
-        proxies: Optional[Dict] = None,
-        resume_download: bool = False,
-        local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
+        **hub_download_kwargs: Any,
     ) -> str:
         """Retrieve the model file from the Huggingface Hub or local directory."""
         if os.path.isdir(model_id):
@@ -93,13 +88,7 @@ class ModelHFHubMixin(HFHubMixin):
             model_file = hf_hub_download(
                 repo_id=model_id,
                 filename=cls.weights_file_name,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                proxies=proxies,
-                resume_download=resume_download,
-                token=token,
-                local_files_only=local_files_only,
+                **hub_download_kwargs,
             )
 
         return model_file
@@ -109,13 +98,21 @@ class ModelHFHubMixin(HFHubMixin):
         cls: Type[TModelHFHubMixin],
         *,
         model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Union[str, bool, None],
+        subfolder: Optional[str] = None,
+        repo_type: Optional[str] = None,
+        revision: Optional[str] = None,
+        library_name: Optional[str] = None,
+        library_version: Optional[str] = None,
+        cache_dir: Union[str, Path, None] = None,
+        local_dir: Union[str, Path, None] = None,
+        user_agent: Union[Dict, str, None] = None,
+        force_download: bool = False,
+        proxies: Optional[Dict] = None,
+        etag_timeout: float = DEFAULT_ETAG_TIMEOUT,
+        token: Union[bool, str, None] = None,
+        local_files_only: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        endpoint: Optional[str] = None,
         config: Optional[dict] = None,
         load_model_file: Optional[Dict[str, Any]] = None,
         **kwargs,
@@ -138,13 +135,21 @@ class ModelHFHubMixin(HFHubMixin):
         model = cls.from_config(config=config or {}, **kwargs)
         model_file = model.retrieve_model_file(
             model_id=model_id,
+            subfolder=subfolder,
+            repo_type=repo_type,
             revision=revision,
+            library_name=library_name,
+            library_version=library_version,
             cache_dir=cache_dir,
+            local_dir=local_dir,
+            user_agent=user_agent,
             force_download=force_download,
             proxies=proxies,
-            resume_download=resume_download,
-            local_files_only=local_files_only,
+            etag_timeout=etag_timeout,
             token=token,
+            local_files_only=local_files_only,
+            headers=headers,
+            endpoint=endpoint,
         )
         # load the model weights
         model.load_model_file(model_file, **load_model_file_kwargs)

--- a/src/pie_core/model.py
+++ b/src/pie_core/model.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Optional, Type, TypeVar, Union
 
 from huggingface_hub.constants import DEFAULT_ETAG_TIMEOUT
 from huggingface_hub.file_download import hf_hub_download

--- a/src/pie_core/taskmodule.py
+++ b/src/pie_core/taskmodule.py
@@ -15,6 +15,7 @@ from typing import (
     Union,
 )
 
+from huggingface_hub.constants import DEFAULT_ETAG_TIMEOUT
 from tqdm import tqdm
 
 from pie_core.auto import Auto
@@ -58,13 +59,21 @@ class TaskModuleHFHubMixin(HFHubMixin):
         cls: Type[TTaskModuleHFHubMixin],
         *,
         model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Union[str, bool, None],
+        subfolder: Optional[str] = None,
+        repo_type: Optional[str] = None,
+        revision: Optional[str] = None,
+        library_name: Optional[str] = None,
+        library_version: Optional[str] = None,
+        cache_dir: Union[str, Path, None] = None,
+        local_dir: Union[str, Path, None] = None,
+        user_agent: Union[Dict, str, None] = None,
+        force_download: bool = False,
+        proxies: Optional[Dict] = None,
+        etag_timeout: float = DEFAULT_ETAG_TIMEOUT,
+        token: Union[bool, str, None] = None,
+        local_files_only: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        endpoint: Optional[str] = None,
         config: Optional[dict] = None,
         **kwargs,
     ) -> TTaskModuleHFHubMixin:

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Type, Union
 
 import pytest
+from huggingface_hub.constants import DEFAULT_ETAG_TIMEOUT
 
 from pie_core import Auto, Registrable
 from pie_core.hf_hub_mixin import HFHubMixin
@@ -19,13 +20,21 @@ class TestHFHubMixin(HFHubMixin):
         cls: Type[HFHubMixin],
         *,
         model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Optional[Union[str, bool]],
+        subfolder: Optional[str] = None,
+        repo_type: Optional[str] = None,
+        revision: Optional[str] = None,
+        library_name: Optional[str] = None,
+        library_version: Optional[str] = None,
+        cache_dir: Union[str, Path, None] = None,
+        local_dir: Union[str, Path, None] = None,
+        user_agent: Union[Dict, str, None] = None,
+        force_download: bool = False,
+        proxies: Optional[Dict] = None,
+        etag_timeout: float = DEFAULT_ETAG_TIMEOUT,
+        token: Union[bool, str, None] = None,
+        local_files_only: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        endpoint: Optional[str] = None,
         config: Optional[dict] = None,
         **kwargs,
     ) -> HFHubMixin:

--- a/tests/test_hf_hub_mixin.py
+++ b/tests/test_hf_hub_mixin.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Type, Union
 
 import pytest
+from huggingface_hub.constants import DEFAULT_ETAG_TIMEOUT
 from huggingface_hub.hf_api import HfApi
 
 from pie_core.hf_hub_mixin import HFHubMixin
@@ -46,13 +47,21 @@ class HFHubObject(HFHubMixin):
         cls: Type[HFHubMixin],
         *,
         model_id: str,
-        revision: Optional[str],
-        cache_dir: Optional[Union[str, Path]],
-        force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
-        local_files_only: bool,
-        token: Optional[Union[str, bool]],
+        subfolder: Optional[str] = None,
+        repo_type: Optional[str] = None,
+        revision: Optional[str] = None,
+        library_name: Optional[str] = None,
+        library_version: Optional[str] = None,
+        cache_dir: Union[str, Path, None] = None,
+        local_dir: Union[str, Path, None] = None,
+        user_agent: Union[Dict, str, None] = None,
+        force_download: bool = False,
+        proxies: Optional[Dict] = None,
+        etag_timeout: float = DEFAULT_ETAG_TIMEOUT,
+        token: Union[bool, str, None] = None,
+        local_files_only: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        endpoint: Optional[str] = None,
         config: Optional[dict] = None,
         **kwargs,
     ) -> HFHubMixin:


### PR DESCRIPTION
This PR adjusts the interface of `from_pretrained` and `save_pretrained` to allow for the parameters of  `huggingface_hub` version [0.23.4](https://github.com/huggingface/huggingface_hub/releases/tag/v0.23.4) (which is our current **min** version) for `hf_hub_download` and `upload_folder`, respectively. 

This also mitigates the warning: 
```
/home/arbi01/.cache/pypoetry/virtualenvs/pie-core-FdWNV-Ov-py3.10/lib/python3.10/site-packages/huggingface_hub/file_download.py:1132: 
FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
```

breaking, because this removes deprecated parameters from `_from_pretrained` (e.g. `resume_download`)